### PR TITLE
Discover webid

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -103,6 +103,7 @@ function createApp (argv = {}) {
     var idp = IdentityProvider({
       store: ldp,
       suffixAcl: ldp.suffixAcl,
+      suffixMeta: ldp.suffixMeta,
       settings: 'settings',
       inbox: 'inbox',
       auth: ldp.auth

--- a/lib/identity-provider.js
+++ b/lib/identity-provider.js
@@ -147,7 +147,7 @@ function createRootMeta (options) {
 
   graph.add(
     sym(options.agent),
-    sym('http://xmlns.com/foaf/0.1/account'),
+    sym('http://www.w3.org/ns/solid/terms#account'),
     sym(options.url))
 
   return graph

--- a/lib/identity-provider.js
+++ b/lib/identity-provider.js
@@ -38,6 +38,7 @@ function IdentityProvider (options) {
   this.suffixURI = options.suffixURI || '#me'
   this.buildURI = options.buildURI || defaultBuildURI
   this.suffixAcl = options.suffixAcl
+  this.suffixMeta = options.suffixMeta
   this.defaultContainers = options.defaultContainers || defaultContainers
   this.inbox = options.inbox
   this.settings = options.settings
@@ -81,6 +82,7 @@ IdentityProvider.prototype.create = function (options, cert, callback) {
   options.agent = options.card + self.suffixURI
   debug('Creating space ' + options.url)
   options.suffixAcl = self.suffixAcl
+  options.suffixMeta = self.suffixMeta
   options.defaultContainers = options.defaultContainers || self.defaultContainers
 
   var settings = options.settings || self.settings
@@ -96,7 +98,10 @@ IdentityProvider.prototype.create = function (options, cert, callback) {
   var graphs = [
     self.putGraph(options.card, createCard(options, cert)),
     self.putGraph(options.card + self.suffixAcl, createCardAcl(options)),
-    self.putGraph(options.url + self.suffixAcl, createRootAcl(options))
+    self.putGraph(options.url + self.suffixAcl, createRootAcl(options)),
+    self.putGraph(options.url + self.suffixMeta, createRootMeta(options)),
+    self.putGraph(options.url + self.suffixMeta + self.suffixAcl,
+       createRootMetaAcl(options))
   ]
   if (options.preferences) {
     graphs.push(self.putGraph(options.preferences, createPreferences(options)))
@@ -135,6 +140,17 @@ IdentityProvider.prototype.create = function (options, cert, callback) {
       callback(err)
     })
   })
+}
+
+function createRootMeta (options) {
+  var graph = $rdf.graph()
+
+  graph.add(
+    sym(options.agent),
+    sym('http://xmlns.com/foaf/0.1/account'),
+    sym(options.url))
+
+  return graph
 }
 
 function createInboxAcl (options) {
@@ -301,22 +317,7 @@ function addReadAll (graph, acl, url) {
     sym('http://www.w3.org/ns/auth/acl#Read'))
 }
 
-// Create an ACL for the WebID card
-function createCardAcl (options) {
-  // Create Card ACL
-  var graph = createAcl(
-    options.card + options.suffixAcl,
-    options.card,
-    options.agent,
-    options.email)
-
-  // Add ReadAll term
-  addReadAll(graph, options.card + options.suffixAcl, options.card)
-
-  return graph
-}
-
-function createAcl (acl, uri, agent, email) {
+function createAcl (acl, uri, agent, email, defaultAll) {
   var graph = $rdf.graph()
   var owner = acl + '#owner'
 
@@ -332,10 +333,12 @@ function createAcl (acl, uri, agent, email) {
     sym(owner),
     sym('http://www.w3.org/ns/auth/acl#agent'),
     sym(agent))
-  graph.add(
-    sym(owner),
-    sym('http://www.w3.org/ns/auth/acl#defaultForNew'),
-    sym(uri))
+  if (defaultAll) {
+    graph.add(
+      sym(owner),
+      sym('http://www.w3.org/ns/auth/acl#defaultForNew'),
+      sym(uri))
+  }
   graph.add(
     sym(owner),
     sym('http://www.w3.org/ns/auth/acl#mode'),
@@ -359,6 +362,20 @@ function createAcl (acl, uri, agent, email) {
   return graph
 }
 
+// Create an ACL for the WebID card
+function createCardAcl (options) {
+  var graph = createAcl(
+    options.card + options.suffixAcl,
+    options.card,
+    options.agent,
+    options.email)
+
+  // Add ReadAll term
+  addReadAll(graph, options.card + options.suffixAcl, options.card)
+
+  return graph
+}
+
 // Create ACL for the space reserved for the new user
 function createRootAcl (options) {
   var graph = createAcl(
@@ -366,6 +383,20 @@ function createRootAcl (options) {
     options.url,
     options.agent,
     options.email)
+
+  return graph
+}
+
+// Create ACL for the space reserved for the new user
+function createRootMetaAcl (options) {
+  var graph = createAcl(
+    options.url + options.suffixAcl,
+    options.url,
+    options.agent)
+
+  // Add ReadAll term
+  addReadAll(graph, options.url + options.suffixMeta + options.suffixAcl,
+    options.url + options.suffixMeta)
 
   return graph
 }

--- a/lib/identity-provider.js
+++ b/lib/identity-provider.js
@@ -317,7 +317,7 @@ function addReadAll (graph, acl, url) {
     sym('http://www.w3.org/ns/auth/acl#Read'))
 }
 
-function createAcl (acl, uri, agent, email, defaultAll) {
+function createAcl (acl, uri, agent, email) {
   var graph = $rdf.graph()
   var owner = acl + '#owner'
 
@@ -333,12 +333,10 @@ function createAcl (acl, uri, agent, email, defaultAll) {
     sym(owner),
     sym('http://www.w3.org/ns/auth/acl#agent'),
     sym(agent))
-  if (defaultAll) {
-    graph.add(
-      sym(owner),
-      sym('http://www.w3.org/ns/auth/acl#defaultForNew'),
-      sym(uri))
-  }
+  graph.add(
+    sym(owner),
+    sym('http://www.w3.org/ns/auth/acl#defaultForNew'),
+    sym(uri))
   graph.add(
     sym(owner),
     sym('http://www.w3.org/ns/auth/acl#mode'),

--- a/test/identity-provider.js
+++ b/test/identity-provider.js
@@ -178,7 +178,7 @@ describe('Identity Provider', function () {
                 'text/turtle')
               var statements = graph.statementsMatching(
                 undefined,
-                $rdf.sym('http://xmlns.com/foaf/0.1/account'),
+                $rdf.sym('http://www.w3.org/ns/solid/terms#account'),
                 undefined)
               if (statements.length === 1) {
                 done()


### PR DESCRIPTION
Switched from `foaf:account` to `solid:account` for discovery.