### PR TITLE
Removed bash text

### DIFF
--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -108,7 +108,7 @@ function bin (argv) {
      n0:               n2:Agent;
      n0:accessTo       <./>;
      n0:defaultForNew  <./>;
-     n0:mode           n0:Read.' > .acl`
+     n0:mode           n0:Read.`
 
     fs.writeFileSync(rootPath, defaultAcl)
   }


### PR DESCRIPTION
The `owner` flag triggers a re-write of the default acl file, which had some trailing bash artifacts when it was copied by hand.