### PR TITLE
Add Accept-Post to Access-Control-Expose-Headers

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -21,7 +21,7 @@ var corsSettings = cors({
   methods: [
     'OPTIONS', 'HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'
   ],
-  exposedHeaders: 'User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Updates-Via, Allow, Content-Length',
+  exposedHeaders: 'User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, Content-Length',
   credentials: true,
   maxAge: 1728000,
   origin: true,

--- a/test/http.js
+++ b/test/http.js
@@ -102,7 +102,7 @@ describe('HTTP APIs', function () {
           .expect('Access-Control-Allow-Origin', 'http://example.com')
           .expect('Access-Control-Allow-Credentials', 'true')
           .expect('Access-Control-Allow-Methods', 'OPTIONS,HEAD,GET,PATCH,POST,PUT,DELETE')
-          .expect('Access-Control-Expose-Headers', 'User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Updates-Via, Allow, Content-Length')
+          .expect('Access-Control-Expose-Headers', 'User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, Content-Length')
           .expect(204, done)
       })
 


### PR DESCRIPTION
Required in order to expose a non-simple header for CORS.