### PR TITLE
Add missing dependency on uid-safe module

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "run-waterfall": "^1.1.3",
     "solid-ws": "^0.2.2",
     "string": "^3.3.0",
+    "uid-safe": "^2.1.1",
     "uuid": "^2.0.1",
     "valid-url": "^1.0.9",
     "vhost": "^3.0.2",


### PR DESCRIPTION
It seems c23f35e0df0c3739b added a dependency on this module but it
wasn't added to config.json.