### PR TITLE
Fix crash on PATCH request with no Content-Type

### DIFF
--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -30,7 +30,9 @@ function patchHandler (req, res, next) {
   var root = !ldp.idp ? ldp.root : ldp.root + req.hostname + '/'
   var filename = utils.uriToFilename(req.path, root)
   var targetContentType = mime.lookup(filename)
-  var patchContentType = req.get('content-type').split(';')[0].trim() // Ignore parameters
+  var patchContentType = req.get('content-type')
+    ? req.get('content-type').split(';')[0].trim() // Ignore parameters
+    : ''
   var targetURI = utils.uriAbs(req) + req.originalUrl
 
   debug('PATCH -- Content-type ' + patchContentType + ' patching target ' + targetContentType + ' <' + targetURI + '>')


### PR DESCRIPTION
When sending a PATCH request without 'Content-Type' header, the server crashes. This PR fixes it.

```
$ curl -E ./dice.crt.pem --key ./dice.key.pem -X PATCH https://axel.webidwebsite.com/profile/card -v --insecure
```
```
  solid:handlers PATCH -- /profile/card +1ms
  solid:handlers PATCH -- text length: undefined2 +0ms
/root/node-solid-server/lib/handlers/patch.js:33
  var patchContentType = req.get('content-type').split(';')[0].trim() // Ignore parameters
                                                ^

TypeError: Cannot read property 'split' of undefined
    at patchHandler (/root/node-solid-server/lib/handlers/patch.js:33:49)
    at IncomingMessage.<anonymous> (/root/node-solid-server/lib/handlers/patch.js:20:5)
    at emitNone (events.js:86:13)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:926:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```