### PR TITLE
Set default content type when a resource has no extension

### DIFF
--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -19,6 +19,8 @@ var rimraf = require('rimraf')
 var ldpContainer = require('./ldp-container')
 var parse = require('./utils').parse
 
+const DEFAULT_CONTENT_TYPE = 'text/turtle'
+
 function LDP (argv) {
   argv = argv || {}
   extend(this, argv)
@@ -319,7 +321,7 @@ LDP.prototype.get = function (host, reqPath, baseUri, includeBody, contentType,
         })
         .on('open', function () {
           debug.handlers('GET -- Read Start.')
-          var contentType = mime.lookup(filename)
+          var contentType = mime.lookup(filename) || DEFAULT_CONTENT_TYPE
           if (utils.hasSuffix(filename, ldp.turtleExtensions)) {
             contentType = 'text/turtle'
           }


### PR DESCRIPTION
Fixes issue #430.