### PR TITLE
Address# 437; upgrade to mashlib-prealpha; switch hosting to github

### DIFF
--- a/static/databrowser.html
+++ b/static/databrowser.html
@@ -1,17 +1,20 @@
 <!DOCTYPE html>
 <html id="docHTML">
 <head>
-    <link type="text/css" rel="stylesheet" href="https://w3.scripts.mit.edu/tabulator/tabbedtab.css" />
-    <script type="text/javascript" src="https://w3.scripts.mit.edu/tabulator/js/mashup/mashlib.js"></script>
+    <link type="text/css" rel="stylesheet" href="https://linkeddata.github.io/solid-app-set/style/tabbedtab.css" />
+    <script type="text/javascript" src="https://linkeddata.github.io/mashlib/dist/mashlib-prealpha.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    $rdf.Fetcher.crossSiteProxyTemplate = document.origin + '/' + ProxyPath + '?uri={uri}'
-    var uri = window.location.href
-    window.document.title = uri
-    var kb = tabulator.kb
-    var subject = kb.sym(uri)
-    tabulator.outline.GotoSubject(subject, true, undefined, true, undefined)
-})
+    var UI = require('mashlib')
+    var $rdf = UI.rdf
+
+    $rdf.Fetcher.crossSiteProxyTemplate = document.origin + '/xss?uri={uri}';
+    var uri = window.location.href;
+    window.document.title = uri;
+    var kb = UI.store;
+    var subject = kb.sym(uri);
+    UI.outline.GotoSubject(subject, true, undefined, true, undefined);
+});
 </script>
 </head>
 <body>


### PR DESCRIPTION
This is a rework of the databrowser default viewer, to have the same basic functionality but
- newer modular version of mashlib
- hosted but github.io 
- fix big with undefined ProxyPath by assuming proxypath is /xss/ 

(Yes, later this could be changed in real time with more code to match the actual proxy addres demanded by the user, but not in this PR)