### PR TITLE
dataBrowserOption option to specify path of db file

### DIFF
--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -115,6 +115,7 @@ module.exports = [
     default: '/proxy',
     prompt: true
   },
+
   {
     name: 'file-browser',
     help: 'Type the URL of default app to use for browsing files (or use default)',
@@ -127,11 +128,22 @@ module.exports = [
     },
     prompt: true
   },
+
   {
-    name: 'data-browser',
+    name: 'suppress-data-browser',
+    help: 'Suppres provision of a data browser',
     flag: true,
-    help: 'Enable viewing RDF resources using a default data browser application (e.g. mashlib)',
-    question: 'Enable data viewer (defaults to using Tabulator)',
+    prompt: true,
+    default: false,
+    hide: false
+  },
+
+  {
+    name: 'data-browser-path',
+    help: 'An HTML file which is sent to allow users to browse the data (eg using mashlib.js)',
+    question: 'Path of data viewer page (defaults to using mashlib)',
+    validate: validPath,
+    default: 'default',
     prompt: true
   },
   {

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -74,7 +74,7 @@ function handler (req, res, next) {
         return res.redirect(303, ldp.fileBrowser + address)
       }
 
-      if (RDFs.indexOf(contentType) >= 0 && !ldp.suppressDataBrowser &&ldp.dataBrowserPath) {
+      if (RDFs.indexOf(contentType) >= 0 && !ldp.suppressDataBrowser && ldp.dataBrowserPath) {
         res.set('Content-Type', 'text/html')
         var defaultDataBrowser = _path.join(__dirname, '../../static/databrowser.html')
         var dataBrowserPath = ldp.dataBrowserPath === 'default' ? defaultDataBrowser : ldp.dataBrowserPath

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -74,10 +74,12 @@ function handler (req, res, next) {
         return res.redirect(303, ldp.fileBrowser + address)
       }
 
-      if (RDFs.indexOf(contentType) >= 0 && ldp.dataBrowser) {
+      if (RDFs.indexOf(contentType) >= 0 && !ldp.suppressDataBrowser &&ldp.dataBrowserPath) {
         res.set('Content-Type', 'text/html')
-        var dataBrowser = _path.join(__dirname, '../../static/databrowser.html')
-        res.sendFile(dataBrowser)
+        var defaultDataBrowser = _path.join(__dirname, '../../static/databrowser.html')
+        var dataBrowserPath = ldp.dataBrowserPath === 'default' ? defaultDataBrowser : ldp.dataBrowserPath
+        debug('   sending data browser file: ' + dataBrowserPath)
+        res.sendFile(dataBrowserPath)
         return
       } else {
         res.setHeader('Content-Type', contentType)

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -57,9 +57,9 @@ class LDP {
         'https://linkeddata.github.io/warp/#/list/'
     }
 
-  if (this.skin !== false) {
-    this.skin = true
-  }
+    if (this.skin !== false) {
+      this.skin = true
+    }
 
     if (this.webid && !this.auth) {
       this.auth = 'tls'

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -57,13 +57,9 @@ class LDP {
         'https://linkeddata.github.io/warp/#/list/'
     }
 
-    if (this.dataBrowser !== false) {
-      this.dataBrowser = true
-    }
-
-    if (this.skin !== false) {
-      this.skin = true
-    }
+  if (this.skin !== false) {
+    this.skin = true
+  }
 
     if (this.webid && !this.auth) {
       this.auth = 'tls'
@@ -80,7 +76,8 @@ class LDP {
     debug.settings('Live-updates: ' + !!this.live)
     debug.settings('Identity Provider: ' + !!this.idp)
     debug.settings('Default file browser app: ' + this.fileBrowser)
-    debug.settings('Default data browser app: ' + this.dataBrowser)
+    debug.settings('Suppress default data browser app: ' + this.suppressDataBrowser)
+    debug.settings('Default data browser app file path: ' + this.dataBrowserPath)
 
     return this
   }

--- a/test/http.js
+++ b/test/http.js
@@ -10,6 +10,7 @@ var suffixAcl = '.acl'
 var suffixMeta = '.meta'
 var ldpServer = ldnode.createServer({
   live: true,
+  dataBrowserPath: 'default',
   root: path.join(__dirname, '/resources')
 })
 var server = supertest(ldpServer)


### PR DESCRIPTION
When re-installing a new version of the server, it overwrites the static/databrowser.html file each time if the usr has customized it.   It is preferable to make the location of the file variable in an option.  The option is --dataBrowserPath

A flag option is called  --suppress-data-browser because calling it no-data-browser has some magic effect of interfering with a data-browser flag in the options package.