### PR TITLE
Add the trailing slash on the URI of a folder listed within a folder

### DIFF
--- a/lib/ldp-container.js
+++ b/lib/ldp-container.js
@@ -44,7 +44,7 @@ function addFile (ldp, resourceGraph, containerUri, reqUri, uri, container, file
       return callback(null)
     }
 
-    let memberUri = reqUri + (  stats.isDirectory() ? '/' : '')
+    let memberUri = reqUri + (stats.isDirectory() ? '/' : '')
     // var fileSubject = file + (stats.isDirectory() ? '/' : '')
     // var fileBaseUri = utils.filenameToBaseUri(fileSubject, uri, root)
 

--- a/lib/ldp-container.js
+++ b/lib/ldp-container.js
@@ -44,24 +44,25 @@ function addFile (ldp, resourceGraph, containerUri, reqUri, uri, container, file
       return callback(null)
     }
 
+    let memberUri = reqUri + (  stats.isDirectory() ? '/' : '')
     // var fileSubject = file + (stats.isDirectory() ? '/' : '')
     // var fileBaseUri = utils.filenameToBaseUri(fileSubject, uri, root)
 
     // Add fileStats to resource Graph
-    addStats(resourceGraph, reqUri, stats)
+    addStats(resourceGraph, memberUri, stats)
 
     // Add to `contains` list
     resourceGraph.add(
       resourceGraph.sym(containerUri),
       ns.ldp('contains'),
-      resourceGraph.sym(reqUri))
+      resourceGraph.sym(memberUri))
 
     // Set up a metaFile path
     var metaFile = container + file +
       (stats.isDirectory() ? '/' : '') +
       (S(file).endsWith(turtleExtension) ? '' : ldp.suffixMeta)
 
-    getMetadataGraph(ldp, metaFile, reqUri, function (err, metadataGraph) {
+    getMetadataGraph(ldp, metaFile, memberUri, function (err, metadataGraph) {
       if (err) {
         metadataGraph = $rdf.graph()
       }
@@ -69,25 +70,25 @@ function addFile (ldp, resourceGraph, containerUri, reqUri, uri, container, file
       // Add Container or BasicContainer types
       if (stats.isDirectory()) {
         resourceGraph.add(
-          metadataGraph.sym(reqUri),
+          metadataGraph.sym(memberUri),
           ns.rdf('type'),
           ns.ldp('BasicContainer'))
 
         resourceGraph.add(
-          metadataGraph.sym(reqUri),
+          metadataGraph.sym(memberUri),
           ns.rdf('type'),
           ns.ldp('Container'))
       }
       // Add generic LDP type
       resourceGraph.add(
-        metadataGraph.sym(reqUri),
+        metadataGraph.sym(memberUri),
         ns.rdf('type'),
         ns.ldp('Resource'))
 
       // Add type from metadataGraph
       metadataGraph
         .statementsMatching(
-          metadataGraph.sym(reqUri),
+          metadataGraph.sym(memberUri),
           ns.rdf('type'),
           undefined)
         .forEach(function (typeStatement) {


### PR DESCRIPTION
Fix bug which forgets the / on end of the URI of a folder  within a f……older being listed

This does not clean up the code with its unnecessary parameters and misleading parameter names (yet)