### PR TITLE
Allow video skip with Accept-Ranges closes #457 #462

### DIFF
--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -31,7 +31,10 @@ function allow (mode) {
       var reqPath = res && res.locals && res.locals.path
         ? res.locals.path
         : req.path
-      ldp.exists(req.hostname, reqPath, (err, stat) => {
+      ldp.exists(req.hostname, reqPath, (err, ret) => {
+        if (ret) {
+          var stat = ret.stream
+        }
         if (!reqPath.endsWith('/') && !err && stat.isDirectory()) {
           reqPath += '/'
         }

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -47,7 +47,15 @@ function handler (req, res, next) {
 
   debug(req.originalUrl + ' on ' + req.hostname)
 
-  ldp.get(req.hostname, path, baseUri, includeBody, possibleRDFType, function (err, stream, contentType, container) {
+  var options = {
+    'hostname': req.hostname,
+    'path': path,
+    'baseUri': baseUri,
+    'includeBody': includeBody,
+    'possibleRDFType': possibleRDFType,
+    'range': req.headers.range
+  }
+  ldp.get(options, function (err, ret) {
     // use globHandler if magic is detected
     if (err && err.status === 404 && glob.hasMagic(path)) {
       debug('forwarding to glob request')
@@ -58,6 +66,14 @@ function handler (req, res, next) {
     if (err) {
       debug(req.method + ' -- Error: ' + err.status + ' ' + err.message)
       return next(err)
+    }
+
+    if (ret) {
+      var stream = ret.stream
+      var contentType = ret.contentType
+      var container = ret.container
+      var contentRange = ret.contentRange
+      var chunksize = ret.chunksize
     }
 
     // Till here it must exist
@@ -91,7 +107,13 @@ function handler (req, res, next) {
     if (negotiator.mediaType([contentType])) {
       debug('no translation ' + contentType)
       res.setHeader('Content-Type', contentType)
-      return stream.pipe(res)
+      if (contentRange) {
+        var headers = { 'Content-Range': contentRange, 'Accept-Ranges': 'bytes', 'Content-Length': chunksize }
+        res.writeHead(206, headers)
+        return stream.pipe(res)
+      } else {
+        return stream.pipe(res)
+      }
     }
 
     // If it is not in our RDFs we can't even translate,

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -25,9 +25,13 @@ function handler (req, res, next) {
   }
 
   // Check if container exists
-  ldp.exists(req.hostname, containerPath, function (err, stats) {
+  ldp.exists(req.hostname, containerPath, function (err, ret) {
     if (err) {
       return next(error(err, 'Container not valid'))
+    }
+
+    if (ret) {
+      var stats = ret.stream
     }
 
     // Check if container is a directory
@@ -99,4 +103,3 @@ function handler (req, res, next) {
       })
   }
 }
-

--- a/lib/identity-provider.js
+++ b/lib/identity-provider.js
@@ -503,13 +503,23 @@ IdentityProvider.prototype.getGraph = function (uri, callback) {
   var hostname = parsed.hostname
   var reqPath = parsed.path
 
-  self.store.get(hostname, reqPath, null, true, 'text/turtle',
-    function (err, stream) {
+  var options = {
+    'hostname': hostname,
+    'path': reqPath,
+    'baseUri': null,
+    'includeBody': true,
+    'possibleRDFType': 'text/turtle'
+  }
+  self.store.get(options,
+    function (err, ret) {
       if (err) {
         debug('Cannot find WebID card')
         var notexists = new Error('Cannot find WebID card')
         notexists.status = 500
         return callback(notexists)
+      }
+      if (ret) {
+        var stream = ret.stream
       }
       var data = ''
       stream

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -324,18 +324,19 @@ class LDP {
             })
         })
       } else {
+        var stream
         if (range) {
           var total = fs.statSync(filename).size
-          var parts = range.replace(/bytes=/, "").split("-")
+          var parts = range.replace(/bytes=/, '').split('-')
           var partialstart = parts[0]
           var partialend = parts[1]
           var start = parseInt(partialstart, 10)
-          var end = partialend ? parseInt(partialend, 10) : total-1
-          var chunksize = (end-start)+1
+          var end = partialend ? parseInt(partialend, 10) : total - 1
+          var chunksize = (end - start) + 1
           var contentRange = 'bytes ' + start + '-' + end + '/' + total
-          var stream = ldp.createReadStream(filename, start, end)
+          stream = ldp.createReadStream(filename, start, end)
         } else {
-          var stream = ldp.createReadStream(filename)
+          stream = ldp.createReadStream(filename)
         }
         stream
           .on('error', function (err) {

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -91,8 +91,12 @@ class LDP {
     })
   }
 
-  createReadStream (filename) {
-    return fs.createReadStream(filename)
+  createReadStream (filename, start, end) {
+    if (start && end) {
+      return fs.createReadStream(filename, {'start': start, 'end': end})
+    } else {
+      return fs.createReadStream(filename)
+    }
   }
 
   readFile (filename, callback) {
@@ -235,7 +239,14 @@ class LDP {
   }
 
   exists (host, reqPath, callback) {
-    this.get(host, reqPath, undefined, false, undefined, callback)
+    var options = {
+      'hostname': host,
+      'path': reqPath,
+      'baseUri': undefined,
+      'includeBody': false,
+      'possibleRDFType': undefined
+    }
+    this.get(options, callback)
   }
 
   graph (host, reqPath, baseUri, contentType, callback) {
@@ -269,7 +280,15 @@ class LDP {
     ], callback)
   }
 
-  get (host, reqPath, baseUri, includeBody, contentType, callback) {
+  get (options, callback) {
+    if (options) {
+      var host = options.hostname
+      var reqPath = options.path
+      var baseUri = options.baseUri
+      var includeBody = options.includeBody
+      var contentType = options.possibleRDFType
+      var range = options.range
+    }
     var ldp = this
     var root = !ldp.idp ? ldp.root : ldp.root + host + '/'
     var filename = utils.uriToFilename(reqPath, root)
@@ -282,7 +301,7 @@ class LDP {
 
       // Just return, since resource exists
       if (!includeBody) {
-        return callback(null, stats, contentType, stats.isDirectory())
+        return callback(null, {'stream': stats, 'contentType': contentType, 'container': stats.isDirectory()})
       }
 
       // Found a container
@@ -301,11 +320,23 @@ class LDP {
               var stream = stringToStream(data)
               // TODO 'text/turtle' is fixed, should be contentType instead
               // This forces one more translation turtle -> desired
-              return callback(null, stream, 'text/turtle', true)
+              return callback(null, {'stream': stream, 'contentType': 'text/turtle', 'container': true})
             })
         })
       } else {
-        var stream = ldp.createReadStream(filename)
+        if (range) {
+          var total = fs.statSync(filename).size
+          var parts = range.replace(/bytes=/, "").split("-")
+          var partialstart = parts[0]
+          var partialend = parts[1]
+          var start = parseInt(partialstart, 10)
+          var end = partialend ? parseInt(partialend, 10) : total-1
+          var chunksize = (end-start)+1
+          var contentRange = 'bytes ' + start + '-' + end + '/' + total
+          var stream = ldp.createReadStream(filename, start, end)
+        } else {
+          var stream = ldp.createReadStream(filename)
+        }
         stream
           .on('error', function (err) {
             debug.handlers('GET -- Read error:' + err.message)
@@ -317,7 +348,7 @@ class LDP {
             if (utils.hasSuffix(filename, ldp.turtleExtensions)) {
               contentType = 'text/turtle'
             }
-            return callback(null, stream, contentType, false)
+            return callback(null, {'stream': stream, 'contentType': contentType, 'container': false, 'contentRange': contentRange, 'chunksize': chunksize})
           })
       }
     })


### PR DESCRIPTION
This PR allows video to be skipped using byte ranges.  

It also refactors ldp.get to use options rather than positional variables in order to provide more flexibility.

Separation of concerns between ldp.js and handers/get.js is maintained