### PR TITLE
Add support for copying from external resources

### DIFF
--- a/lib/handlers/copy.js
+++ b/lib/handlers/copy.js
@@ -4,6 +4,7 @@ const debug = require('../debug')
 const error = require('../http-error')
 const ldpCopy = require('../ldp-copy')
 const utils = require('../utils')
+const url = require('url')
 
 /**
  * Handles HTTP COPY requests to import a given resource (specified in the
@@ -18,8 +19,9 @@ function handler (req, res, next) {
   if (!copyFrom) {
     return next(error(400, 'Source header required'))
   }
+  const fromExternal = !!url.parse(copyFrom).hostname
   const serverRoot = utils.uriBase(req)
-  const copyFromUrl = serverRoot + copyFrom
+  const copyFromUrl = fromExternal ? copyFrom : serverRoot + copyFrom
   const copyTo = res.locals.path || req.path
   const copyToPath = utils.reqToPath(req)
   ldpCopy(copyToPath, copyFromUrl, function (err) {


### PR DESCRIPTION
The http copy functionality currently only supports relative paths in the `Source` header (e.g. `/resources/samplePublicContainer/nicola.jpg`)  This PR maintains support for that functionality while adding in support for external resources as well (e.g. `https://example.com/foo.json`)