### PR TITLE
Disable crashing verifyDelegator() code in allow() handler

### DIFF
--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -94,50 +94,51 @@ function fetchDocument (host, ldp, baseUri) {
 }
 
 function getUserId (req, callback) {
-  var onBehalfOf = req.get('On-Behalf-Of')
-  if (!onBehalfOf) {
-    return callback(null, req.session.userId)
-  }
-
-  var delegator = utils.debrack(onBehalfOf)
-  verifyDelegator(req.hostname, delegator, req.session.userId,
-    function (err, res) {
-      if (err) {
-        err.status = 500
-        return callback(err)
-      }
-
-      if (res) {
-        debug('Request User ID (delegation) :' + delegator)
-        return callback(null, delegator)
-      }
-      return callback(null, req.session.userId)
-    })
+  callback(null, req.session.userId)
+  // var onBehalfOf = req.get('On-Behalf-Of')
+  // if (!onBehalfOf) {
+  //   return callback(null, req.session.userId)
+  // }
+  //
+  // var delegator = utils.debrack(onBehalfOf)
+  // verifyDelegator(req.hostname, delegator, req.session.userId,
+  //   function (err, res) {
+  //     if (err) {
+  //       err.status = 500
+  //       return callback(err)
+  //     }
+  //
+  //     if (res) {
+  //       debug('Request User ID (delegation) :' + delegator)
+  //       return callback(null, delegator)
+  //     }
+  //     return callback(null, req.session.userId)
+  //   })
 }
 
-function verifyDelegator (host, ldp, baseUri, delegator, delegatee, callback) {
-  fetchDocument(host, ldp, baseUri)(delegator, function (err, delegatorGraph) {
-    // TODO handle error
-    if (err) {
-      err.status = 500
-      return callback(err)
-    }
-
-    var delegatesStatements = delegatorGraph
-      .each(delegatorGraph.sym(delegator),
-        delegatorGraph.sym('http://www.w3.org/ns/auth/acl#delegates'),
-        undefined)
-
-    for (var delegateeIndex in delegatesStatements) {
-      var delegateeValue = delegatesStatements[delegateeIndex]
-      if (utils.debrack(delegateeValue.toString()) === delegatee) {
-        callback(null, true)
-      }
-    }
-    // TODO check if this should be false
-    return callback(null, false)
-  })
-}
+// function verifyDelegator (host, ldp, baseUri, delegator, delegatee, callback) {
+//   fetchDocument(host, ldp, baseUri)(delegator, function (err, delegatorGraph) {
+//     // TODO handle error
+//     if (err) {
+//       err.status = 500
+//       return callback(err)
+//     }
+//
+//     var delegatesStatements = delegatorGraph
+//       .each(delegatorGraph.sym(delegator),
+//         delegatorGraph.sym('http://www.w3.org/ns/auth/acl#delegates'),
+//         undefined)
+//
+//     for (var delegateeIndex in delegatesStatements) {
+//       var delegateeValue = delegatesStatements[delegateeIndex]
+//       if (utils.debrack(delegateeValue.toString()) === delegatee) {
+//         callback(null, true)
+//       }
+//     }
+//     // TODO check if this should be false
+//     return callback(null, false)
+//   })
+// }
 /**
  * Callback used by verifyDelegator.
  * @callback ACL~verifyDelegator_cb


### PR DESCRIPTION
Currently, making any request to node-solid-server that has an `On-Behalf-Of:` HTTP header crashes the server (issue #473).
To address current crashes in production, this PR disables `verifyDelegator()` and related code until it can be fixed in PR #475.