### PR TITLE
enable HTTP/2

### DIFF
--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -2,7 +2,7 @@ module.exports = createServer
 
 var express = require('express')
 var fs = require('fs')
-var https = require('https')
+var http2 = require('spdy')
 var http = require('http')
 var SolidWs = require('solid-ws')
 var debug = require('./debug')
@@ -62,7 +62,7 @@ function createServer (argv, app) {
       credentials.requestCert = true
     }
 
-    server = https.createServer(credentials, app)
+    server = http2.createServer(credentials, app)
   }
 
   // Setup Express app

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "solid-namespace": "^0.1.0",
     "solid-permissions": "^0.5.1",
     "solid-ws": "^0.2.3",
+    "spdy": "^3.4.4",
     "string": "^3.3.0",
     "uid-safe": "^2.1.1",
     "uuid": "^3.0.0",


### PR DESCRIPTION
it uses `spdy` module since `http2` doesn't work well with current express https://github.com/expressjs/express/issues/2364#issuecomment-260167854