### PR TITLE
Add and test Node 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - "6.0"
+  - "8.0"
+  - "node"
 env:
   - CXX=g++-4.8
 

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -57,10 +57,10 @@ function createServer (argv, app) {
       throw new Error('Can\'t find SSL cert in ' + argv.sslCert)
     }
 
-    var credentials = {
+    var credentials = Object.assign({
       key: key,
       cert: cert
-    }
+    }, argv)
 
     if (ldp.webid && ldp.auth === 'tls') {
       credentials.requestCert = true

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -10,9 +10,6 @@ var async = require('async')
 var debug = require('../debug').ACL
 var utils = require('../utils')
 
-// TODO should this be set?
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
 function allow (mode) {
   return function allowHandler (req, res, next) {
     var ldp = req.app.locals.ldp

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "scripts": {
     "solid": "node ./bin/solid.js",
     "standard": "standard",
-    "mocha": "nyc mocha ./test/**/*.js",
+    "mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 nyc mocha ./test/**/*.js",
     "test": "npm run standard && npm run mocha",
     "test-integration": "mocha ./test/integration/*.js",
     "test-unit": "mocha ./test/unit/*.js",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "dirty-chai": "^1.2.2",
     "hippie": "^0.5.0",
     "mocha": "^3.2.0",
-    "nock": "^9.0.2",
+    "nock": "^9.0.14",
     "node-mocks-http": "^1.5.6",
     "nyc": "^10.1.2",
     "proxyquire": "^1.7.10",

--- a/test/integration/account-creation-oidc.js
+++ b/test/integration/account-creation-oidc.js
@@ -8,7 +8,6 @@ const path = require('path')
 const fs = require('fs-extra')
 
 describe('AccountManager (OIDC account creation tests)', function () {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
   this.timeout(10000)
 
   var serverUri = 'https://localhost:3457'

--- a/test/integration/account-creation-tls.js
+++ b/test/integration/account-creation-tls.js
@@ -9,7 +9,6 @@
 //
 // describe('AccountManager (TLS account creation tests)', function () {
 //   this.timeout(10000)
-//   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 //
 //   var address = 'https://localhost:3457'
 //   var host = 'localhost:3457'

--- a/test/integration/acl-tls.js
+++ b/test/integration/acl-tls.js
@@ -53,8 +53,6 @@ var userCredentials = {
 
 describe('ACL with WebID+TLS', function () {
   this.timeout(10000)
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
   var ldpHttpsServer
   var ldp = ldnode.createServer({
     mount: '/test',
@@ -63,7 +61,8 @@ describe('ACL with WebID+TLS', function () {
     sslCert: path.join(__dirname, '../keys/cert.pem'),
     webid: true,
     strictOrigin: true,
-    auth: 'tls'
+    auth: 'tls',
+    rejectUnauthorized: false
   })
 
   before(function (done) {

--- a/test/integration/errors-oidc.js
+++ b/test/integration/errors-oidc.js
@@ -5,8 +5,6 @@ const fs = require('fs-extra')
 const expect = require('chai').expect
 
 describe('OIDC error handling', function () {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
   const serverUri = 'https://localhost:3457'
   var ldpHttpsServer
   const rootPath = path.join(__dirname, '../resources/accounts/errortests')

--- a/test/integration/http-copy.js
+++ b/test/integration/http-copy.js
@@ -9,8 +9,6 @@ var solidServer = require('../../index')
 
 describe('HTTP COPY API', function () {
   this.timeout(10000)
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
-
   var address = 'https://localhost:3456'
 
   var ldpHttpsServer


### PR DESCRIPTION
The server tests now run with Node 8, and this is tested on Travis.

The main problem was that setting `NODE_TLS_REJECT_UNAUTHORIZED` at runtime through `process.env` didn't work anymore. I have replaced this by the `rejectUnauthorized` configuration option where possible, which fixed the ACL TLS test (and can be useful for local testing). Unfortunately, the supertest library does not allow to set that option, so I set is a an environment variable before calling the Mocha tests.

The remaining problem is that Nock is currently incompatible with Node 8, so for now, I have just skipped those 4 tests that use Nock.