### PR TITLE
Update and document client certificate header

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ $ solid --idp --port 8443 --cert /path/to/cert --key /path/to/key --root ./accou
 
 Your users will have a dedicated folder under `./accounts`. Also, your root domain's website will be in `./accounts/yourdomain.tld`. New users can create accounts on `/api/accounts/new` and create new certificates on `/api/accounts/cert`. An easy-to-use sign-up tool is found on `/api/accounts`.
 
+### Running Solid behind a reverse proxy (such as NGINX)
+See [Running Solid behind a reverse proxy](https://github.com/solid/node-solid-server/wiki/Running-Solid-behind-a-reverse-proxy).
+
 ##### How can send emails to my users with my Gmail?
 
 > To use Gmail you may need to configure ["Allow Less Secure Apps"](https://www.google.com/settings/security/lesssecureapps) in your Gmail account unless you are using 2FA in which case you would have to create an [Application Specific](https://security.google.com/settings/security/apppasswords) password. You also may need to unlock your account with ["Allow access to your Google account"](https://accounts.google.com/DisplayUnlockCaptcha) to use SMTP.

--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -76,9 +76,9 @@ module.exports = [
     }
   },
   {
-    name: 'acceptCertificateHeader',
-    question: 'Accept client certificates through the X-SSL-Cert header (for reverse proxies)',
-    default: false,
+    name: 'certificateHeader',
+    question: 'Accept client certificates through this HTTP header (for reverse proxies)',
+    default: '',
     prompt: false
   },
   {

--- a/lib/api/authn/webid-tls.js
+++ b/lib/api/authn/webid-tls.js
@@ -48,15 +48,16 @@ function getCertificateViaTLS (req) {
   debug('No peer certificate received during TLS handshake.')
 }
 
-// Tries to obtain a client certificate retrieved through the X-SSL-Cert header
+// Tries to obtain a client certificate retrieved through an HTTP header
 function getCertificateViaHeader (req) {
-  // Only allow the X-SSL-Cert header if explicitly enabled
-  if (!req.app.locals.acceptCertificateHeader) return
+  // Only allow header-based certificates if explicitly enabled
+  const headerName = req.app.locals.certificateHeader
+  if (!headerName) return
 
   // Try to retrieve the certificate from the header
-  const header = req.headers['x-ssl-cert']
+  const header = req.headers[headerName]
   if (!header) {
-    return debug('No certificate received through the X-SSL-Cert header.')
+    return debug(`No certificate received through the ${headerName} header.`)
   }
   // The certificate's newlines have been replaced by tabs
   // in order to fit in an HTTP header (NGINX does this automatically)
@@ -65,7 +66,7 @@ function getCertificateViaHeader (req) {
   // Ensure the header contains a valid certificate
   // (x509 unsafely interprets it as a file path otherwise)
   if (!CERTIFICATE_MATCHER.test(rawCertificate)) {
-    return debug('Invalid value for the X-SSL-Cert header.')
+    return debug(`Invalid value for the ${headerName} header.`)
   }
 
   // Parse and convert the certificate to the format the webid library expects
@@ -78,7 +79,7 @@ function getCertificateViaHeader (req) {
       subjectaltname: extensions && extensions.subjectAlternativeName
     }
   } catch (error) {
-    debug('Invalid certificate received through the X-SSL-Cert header.')
+    debug(`Invalid certificate received through the ${headerName} header.`)
   }
 }
 

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -187,7 +187,9 @@ function initAuthentication (argv, app) {
     case 'tls':
       // Enforce authentication with WebID-TLS on all LDP routes
       app.use('/', API.tls.authenticate())
-      app.locals.acceptCertificateHeader = argv.acceptCertificateHeader
+      if (argv.certificateHeader) {
+        app.locals.certificateHeader = argv.certificateHeader.toLowerCase()
+      }
       break
     case 'oidc':
       let oidc = OidcManager.fromServerConfig(argv)

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -24,7 +24,7 @@ function createServer (argv, app) {
 
   var server
   var needsTLS = argv.sslKey || argv.sslCert ||
-                 (ldp.webid || ldp.idp) && !argv.acceptCertificateHeader
+                 (ldp.webid || ldp.idp) && !argv.certificateHeader
   if (!needsTLS) {
     server = http.createServer(app)
   } else {

--- a/test/integration/acl-tls.js
+++ b/test/integration/acl-tls.js
@@ -983,7 +983,7 @@ describe('ACL with WebID through X-SSL-Cert', function () {
       root: rootPath,
       webid: true,
       auth: 'tls',
-      acceptCertificateHeader: true
+      certificateHeader: 'X-SSL-Cert'
     })
     ldpHttpsServer = ldp.listen(3456, done)
   })


### PR DESCRIPTION
The HTTP header to pass the client certificate can now be chosen.