### PR TITLE
Reject cookies from third-party applications

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -20,6 +20,7 @@ const OidcManager = require('./models/oidc-manager')
 const config = require('./server-config')
 const defaults = require('../config/defaults')
 const options = require('./handlers/options')
+const debug = require('./debug').authentication
 
 const corsSettings = cors({
   methods: [
@@ -143,9 +144,29 @@ function initViews (app, configPath) {
 function initWebId (argv, app, ldp) {
   config.ensureWelcomePage(argv)
 
-  // Use session cookies
+  // Store the user's session key in a cookie
+  // (for same-domain browsing by people only)
   const useSecureCookies = argv.webid  // argv.webid forces https and secure cookies
-  app.use(session(sessionSettings(useSecureCookies, argv.host)))
+  const sessionHandler = session(sessionSettings(useSecureCookies, argv.host))
+  app.use((req, res, next) => {
+    sessionHandler(req, res, () => {
+      // Reject cookies from third-party applications.
+      // Otherwise, when a user is logged in to their Solid server,
+      // any third-party application could perform authenticated requests
+      // without permission by including the credentials set by the Solid server.
+      const origin = req.headers.origin
+      const userId = req.session.userId
+      if (!argv.host.allowsSessionFor(userId, origin)) {
+        debug(`Rejecting session for ${userId} from ${origin}`)
+        // Destroy session data
+        delete req.session.userId
+        delete req.session.identified
+        // Ensure this modified session is not saved
+        req.session.save = (done) => done()
+      }
+      next()
+    })
+  })
 
   let accountManager = AccountManager.from({
     authMethod: argv.auth,

--- a/lib/models/solid-host.js
+++ b/lib/models/solid-host.js
@@ -61,6 +61,25 @@ class SolidHost {
     }
     return this.parsedUri.protocol + '//' + accountName + '.' + this.host
   }
+  /**
+   * Determines whether the given user is allowed to restore a session
+   * from the given origin.
+   *
+   * @param userId {?string}
+   * @param origin {?string}
+   * @return {boolean}
+   */
+  allowsSessionFor (userId, origin) {
+    // Allow no user or an empty origin
+    if (!userId || !origin) return true
+    // Allow the server's main domain
+    if (origin === this.serverUri) return true
+    // Allow the user's subdomain
+    const userIdHost = userId.replace(/([^:/])\/.*/, '$1')
+    if (origin === userIdHost) return true
+    // Disallow everything else
+    return false
+  }
 
   /**
    * Returns the /authorize endpoint URL object (used in login requests, etc).

--- a/test/resources/accounts-scenario/alice/.acl
+++ b/test/resources/accounts-scenario/alice/.acl
@@ -1,5 +1,5 @@
 <#Owner>
  a <http://www.w3.org/ns/auth/acl#Authorization> ;
  <http://www.w3.org/ns/auth/acl#accessTo> <./>;
- <http://www.w3.org/ns/auth/acl#agent> <https://127.0.0.1:5000/profile/card#me>;
+ <http://www.w3.org/ns/auth/acl#agent> <https://localhost:7000/profile/card#me>;
  <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .

--- a/test/unit/solid-host.js
+++ b/test/unit/solid-host.js
@@ -26,7 +26,7 @@ describe('SolidHost', () => {
     })
   })
 
-  describe('uriForAccount()', () => {
+  describe('accountUriFor()', () => {
     it('should compose an account uri for an account name', () => {
       let config = {
         serverUri: 'https://test.local'
@@ -39,6 +39,39 @@ describe('SolidHost', () => {
     it('should throw an error if no account name is passed in', () => {
       let host = SolidHost.from()
       expect(() => { host.accountUriFor() }).to.throw(TypeError)
+    })
+  })
+
+  describe('allowsSessionFor()', () => {
+    let host
+    before(() => {
+      host = SolidHost.from({
+        serverUri: 'https://test.local'
+      })
+    })
+
+    it('should allow an empty userId and origin', () => {
+      expect(host.allowsSessionFor('', '')).to.be.true
+    })
+
+    it('should allow a userId with empty origin', () => {
+      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', '')).to.be.true
+    })
+
+    it('should allow a userId with the user subdomain as origin', () => {
+      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://user.test.local')).to.be.true
+    })
+
+    it('should disallow a userId with another subdomain as origin', () => {
+      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://other.test.local')).to.be.false
+    })
+
+    it('should allow a userId with the server domain as origin', () => {
+      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://test.local')).to.be.true
+    })
+
+    it('should disallow a userId from a different domain', () => {
+      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://other.remote')).to.be.false
     })
   })
 


### PR DESCRIPTION
Otherwise, when a user is logged in to their Solid server,
any third-party application could perform authenticated requests
without permission by including the credentials set by the Solid server.

Closes #524. Breaking change, needs new semver-major.

Note: this breaks Warp, which currently relies on cookie-based authentication (https://github.com/linkeddata/warp/issues/23).