### PR TITLE
Split user ID extraction and ACL checking

### DIFF
--- a/lib/api/authn/force-user.js
+++ b/lib/api/authn/force-user.js
@@ -9,7 +9,6 @@ function initialize (app, argv) {
   app.use('/', (req, res, next) => {
     debug(`Identified user (override): ${forceUserId}`)
     req.session.userId = forceUserId
-    req.session.identified = true
     res.set('User', forceUserId)
     next()
   })

--- a/lib/api/authn/force-user.js
+++ b/lib/api/authn/force-user.js
@@ -9,7 +9,9 @@ function initialize (app, argv) {
   app.use('/', (req, res, next) => {
     debug(`Identified user (override): ${forceUserId}`)
     req.session.userId = forceUserId
-    res.set('User', forceUserId)
+    if (argv.auth === 'tls') {
+      res.set('User', forceUserId)
+    }
     next()
   })
 }

--- a/lib/api/authn/force-user.js
+++ b/lib/api/authn/force-user.js
@@ -1,0 +1,20 @@
+const debug = require('../../debug').authentication
+
+/**
+ * Enforces the `--force-user` server flag, hardcoding a webid for all requests,
+ * for testing purposes.
+ */
+function initialize (app, argv) {
+  const forceUserId = argv.forceUser
+  app.use('/', (req, res, next) => {
+    debug(`Identified user (override): ${forceUserId}`)
+    req.session.userId = forceUserId
+    req.session.identified = true
+    res.set('User', forceUserId)
+    next()
+  })
+}
+
+module.exports = {
+  initialize
+}

--- a/lib/api/authn/index.js
+++ b/lib/api/authn/index.js
@@ -1,23 +1,5 @@
-'use strict'
-
-const debug = require('../../debug').authentication
-
-/**
- * Enforces the `--force-user` server flag, hardcoding a webid for all requests,
- * for testing purposes.
- */
-function overrideWith (forceUserId) {
-  return (req, res, next) => {
-    req.session.userId = forceUserId
-    req.session.identified = true
-    debug('Identified user (override): ' + forceUserId)
-    res.set('User', forceUserId)
-    return next()
-  }
-}
-
 module.exports = {
   oidc: require('./webid-oidc'),
   tls: require('./webid-tls'),
-  overrideWith
+  forceUser: require('./force-user.js')
 }

--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -33,6 +33,14 @@ function initialize (app, argv) {
   app.use('/', middleware(oidc))
   // Perform the actual authentication
   app.use('/', oidc.rs.authenticate())
+  // Expose session.userId
+  app.use('/', (req, res, next) => {
+    const userId = oidc.webIdFromClaims(req.claims)
+    if (userId) {
+      req.session.userId = userId
+    }
+    next()
+  })
 }
 
 /**

--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -5,6 +5,7 @@
 
 const express = require('express')
 const bodyParser = require('body-parser').urlencoded({ extended: false })
+const OidcManager = require('../../models/oidc-manager')
 
 const { LoginRequest } = require('../../requests/login-request')
 
@@ -16,6 +17,23 @@ const {
   LogoutRequest,
   SelectProviderRequest
 } = require('oidc-auth-manager').handlers
+
+/**
+ * Sets up OIDC authentication for the given app.
+ *
+ * @param app {Object} Express.js app instance
+ * @param argv {Object} Config options hashmap
+ */
+function initialize (app, argv) {
+  const oidc = OidcManager.fromServerConfig(argv)
+  app.locals.oidc = oidc
+  oidc.initialize()
+
+  // Attach the OIDC API
+  app.use('/', middleware(oidc))
+  // Perform the actual authentication
+  app.use('/', oidc.rs.authenticate())
+}
 
 /**
  * Returns a router with OIDC Relying Party and Identity Provider middleware:
@@ -137,6 +155,7 @@ function isEmptyToken (req) {
 }
 
 module.exports = {
+  initialize,
   isEmptyToken,
   middleware,
   setAuthenticateHeader,

--- a/lib/api/authn/webid-tls.js
+++ b/lib/api/authn/webid-tls.js
@@ -13,7 +13,7 @@ function initialize (app, argv) {
 
 function handler (req, res, next) {
   // User already logged in? skip
-  if (req.session.userId && req.session.identified) {
+  if (req.session.userId) {
     debug('User: ' + req.session.userId)
     res.set('User', req.session.userId)
     return next()
@@ -34,7 +34,6 @@ function handler (req, res, next) {
       return next()
     }
     req.session.userId = result
-    req.session.identified = true
     debug('Identified user: ' + req.session.userId)
     res.set('User', req.session.userId)
     return next()
@@ -88,7 +87,6 @@ function getCertificateViaHeader (req) {
 
 function setEmptySession (req) {
   req.session.userId = ''
-  req.session.identified = false
 }
 
 /**

--- a/lib/api/authn/webid-tls.js
+++ b/lib/api/authn/webid-tls.js
@@ -4,8 +4,11 @@ var x509 // optional dependency, load lazily
 
 const CERTIFICATE_MATCHER = /^-----BEGIN CERTIFICATE-----\n(?:[A-Za-z0-9+/=]+\n)+-----END CERTIFICATE-----$/m
 
-function authenticate () {
-  return handler
+function initialize (app, argv) {
+  app.use('/', handler)
+  if (argv.certificateHeader) {
+    app.locals.certificateHeader = argv.certificateHeader.toLowerCase()
+  }
 }
 
 function handler (req, res, next) {
@@ -102,7 +105,7 @@ function setAuthenticateHeader (req, res) {
 }
 
 module.exports = {
-  authenticate,
+  initialize,
   handler,
   setAuthenticateHeader,
   setEmptySession

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -2,7 +2,5 @@
 
 module.exports = {
   authn: require('./authn'),
-  oidc: require('./authn/webid-oidc'),
-  tls: require('./authn/webid-tls'),
   accounts: require('./accounts/user-accounts')
 }

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -205,11 +205,7 @@ function initAuthentication (app, argv) {
 
   switch (authMethod) {
     case 'tls':
-      // Enforce authentication with WebID-TLS on all LDP routes
-      app.use('/', API.tls.authenticate())
-      if (argv.certificateHeader) {
-        app.locals.certificateHeader = argv.certificateHeader.toLowerCase()
-      }
+      API.tls.initialize(app, argv)
       break
     case 'oidc':
       API.oidc.initialize(app, argv)

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -196,23 +196,11 @@ function initWebId (argv, app, ldp) {
  * @param argv {Object} Config options hashmap
  */
 function initAuthentication (app, argv) {
-  let authMethod = argv.auth
-
-  if (argv.forceUser) {
-    API.authn.forceUser.initialize(app, argv)
-    return
+  const auth = argv.forceUser ? 'forceUser' : argv.auth
+  if (!(auth in API.authn)) {
+    throw new Error(`Unsupported authentication scheme: ${auth}`)
   }
-
-  switch (authMethod) {
-    case 'tls':
-      API.tls.initialize(app, argv)
-      break
-    case 'oidc':
-      API.oidc.initialize(app, argv)
-      break
-    default:
-      throw new TypeError('Unsupported authentication scheme')
-  }
+  API.authn[auth].initialize(app, argv)
 }
 
 /**

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -199,7 +199,7 @@ function initAuthentication (app, argv) {
   let authMethod = argv.auth
 
   if (argv.forceUser) {
-    app.use('/', API.authn.overrideWith(argv.forceUser))
+    API.authn.forceUser.initialize(app, argv)
     return
   }
 

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -159,7 +159,6 @@ function initWebId (argv, app, ldp) {
         debug(`Rejecting session for ${userId} from ${origin}`)
         // Destroy session data
         delete req.session.userId
-        delete req.session.identified
         // Ensure this modified session is not saved
         req.session.save = (done) => done()
       }

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -16,7 +16,6 @@ const TokenService = require('./models/token-service')
 const capabilityDiscovery = require('./capability-discovery')
 const API = require('./api')
 const errorPages = require('./handlers/error-pages')
-const OidcManager = require('./models/oidc-manager')
 const config = require('./server-config')
 const defaults = require('../config/defaults')
 const options = require('./handlers/options')
@@ -183,7 +182,7 @@ function initWebId (argv, app, ldp) {
   app.use('/', API.accounts.middleware(accountManager))
 
   // Set up authentication-related API endpoints and app.locals
-  initAuthentication(argv, app)
+  initAuthentication(app, argv)
 
   if (argv.idp) {
     app.use(vhost('*', LdpMiddleware(corsSettings)))
@@ -193,10 +192,10 @@ function initWebId (argv, app, ldp) {
 /**
  * Sets up authentication-related routes and handlers for the app.
  *
+ * @param app {Object} Express.js app instance
  * @param argv {Object} Config options hashmap
- * @param app {Function} Express.js app instance
  */
-function initAuthentication (argv, app) {
+function initAuthentication (app, argv) {
   let authMethod = argv.auth
 
   if (argv.forceUser) {
@@ -213,19 +212,7 @@ function initAuthentication (argv, app) {
       }
       break
     case 'oidc':
-      let oidc = OidcManager.fromServerConfig(argv)
-      app.locals.oidc = oidc
-
-      oidc.initialize()
-
-      // Initialize the WebId-OIDC authentication routes/api, including:
-      // user-facing Solid endpoints (/login, /logout, /api/auth/select-provider)
-      // and OIDC-specific ones
-      app.use('/', API.oidc.middleware(oidc))
-
-      // Enforce authentication with WebID-OIDC on all LDP routes
-      app.use('/', oidc.rs.authenticate())
-
+      API.oidc.initialize(app, argv)
       break
     default:
       throw new TypeError('Unsupported authentication scheme')

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -1,7 +1,4 @@
-module.exports = {
-  allow,
-  userIdFromRequest
-}
+module.exports = allow
 
 var ACL = require('../acl-checker')
 var $rdf = require('rdflib')
@@ -26,26 +23,21 @@ function allow (mode) {
     })
     req.acl = acl
 
-    getUserId(req, function (err, userId) {
-      if (err) return next(err)
-      req.userId = userId
-
-      var reqPath = res && res.locals && res.locals.path
-        ? res.locals.path
-        : req.path
-      ldp.exists(req.hostname, reqPath, (err, ret) => {
-        if (ret) {
-          var stat = ret.stream
-        }
-        if (!reqPath.endsWith('/') && !err && stat.isDirectory()) {
-          reqPath += '/'
-        }
-        var options = {
-          origin: req.get('origin'),
-          host: req.protocol + '://' + req.get('host')
-        }
-        return acl.can(userId, mode, baseUri + reqPath, next, options)
-      })
+    var reqPath = res && res.locals && res.locals.path
+      ? res.locals.path
+      : req.path
+    ldp.exists(req.hostname, reqPath, (err, ret) => {
+      if (ret) {
+        var stat = ret.stream
+      }
+      if (!reqPath.endsWith('/') && !err && stat.isDirectory()) {
+        reqPath += '/'
+      }
+      var options = {
+        origin: req.get('origin'),
+        host: req.protocol + '://' + req.get('host')
+      }
+      return acl.can(req.session.userId, mode, baseUri + reqPath, next, options)
     })
   }
 }
@@ -94,80 +86,3 @@ function fetchDocument (host, ldp, baseUri) {
     ], callback)
   }
 }
-
-/**
- * Extracts the Web ID from the request object (for purposes of access control).
- *
- * @param req {IncomingRequest}
- *
- * @return {string|null} Web ID
- */
-function userIdFromRequest (req) {
-  let userId
-  let locals = req.app.locals
-
-  if (req.session.userId) {
-    userId = req.session.userId
-  } else if (locals.authMethod === 'oidc') {
-    userId = locals.oidc.webIdFromClaims(req.claims)
-  }
-
-  return userId
-}
-
-function getUserId (req, callback) {
-  let userId = userIdFromRequest(req)
-
-  callback(null, userId)
-  // var onBehalfOf = req.get('On-Behalf-Of')
-  // if (!onBehalfOf) {
-  //   return callback(null, req.session.userId)
-  // }
-  //
-  // var delegator = utils.debrack(onBehalfOf)
-  // verifyDelegator(req.hostname, delegator, req.session.userId,
-  //   function (err, res) {
-  //     if (err) {
-  //       err.status = 500
-  //       return callback(err)
-  //     }
-  //
-  //     if (res) {
-  //       debug('Request User ID (delegation) :' + delegator)
-  //       return callback(null, delegator)
-  //     }
-  //     return callback(null, req.session.userId)
-  //   })
-}
-
-// function verifyDelegator (host, ldp, baseUri, delegator, delegatee, callback) {
-//   fetchDocument(host, ldp, baseUri)(delegator, function (err, delegatorGraph) {
-//     // TODO handle error
-//     if (err) {
-//       err.status = 500
-//       return callback(err)
-//     }
-//
-//     var delegatesStatements = delegatorGraph
-//       .each(delegatorGraph.sym(delegator),
-//         delegatorGraph.sym('http://www.w3.org/ns/auth/acl#delegates'),
-//         undefined)
-//
-//     for (var delegateeIndex in delegatesStatements) {
-//       var delegateeValue = delegatesStatements[delegateeIndex]
-//       if (utils.debrack(delegateeValue.toString()) === delegatee) {
-//         callback(null, true)
-//       }
-//     }
-//     // TODO check if this should be false
-//     return callback(null, false)
-//   })
-// }
-/**
- * Callback used by verifyDelegator.
- * @callback ACL~verifyDelegator_cb
- * @param {Object} err Error occurred when reading the acl file
- * @param {Number} err.status Status code of the error (HTTP way)
- * @param {String} err.message Reason of the error
- * @param {Boolean} result verification has passed or not
- */

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -11,7 +11,7 @@ const url = require('url')
 
 var debug = require('debug')('solid:get')
 var debugGlob = require('debug')('solid:glob')
-var acl = require('./allow')
+var allow = require('./allow')
 
 var utils = require('../utils.js')
 var translate = require('../utils.js').translate
@@ -200,7 +200,7 @@ function aclAllow (match, req, res, callback) {
   var root = ldp.idp ? ldp.root + req.hostname + '/' : ldp.root
   var relativePath = '/' + _path.relative(root, match)
   res.locals.path = relativePath
-  acl.allow('Read', req, res, function (err) {
+  allow('Read', req, res, function (err) {
     callback(err)
   })
 }

--- a/lib/ldp-middleware.js
+++ b/lib/ldp-middleware.js
@@ -2,7 +2,7 @@ module.exports = LdpMiddleware
 
 var express = require('express')
 var header = require('./header')
-var acl = require('./handlers/allow')
+var allow = require('./handlers/allow')
 var get = require('./handlers/get')
 var post = require('./handlers/post')
 var put = require('./handlers/put')
@@ -21,12 +21,12 @@ function LdpMiddleware (corsSettings) {
     router.use(corsSettings)
   }
 
-  router.copy('/*', acl.allow('Write'), copy)
-  router.get('/*', index, acl.allow('Read'), get)
-  router.post('/*', acl.allow('Append'), post)
-  router.patch('/*', acl.allow('Write'), patch)
-  router.put('/*', acl.allow('Write'), put)
-  router.delete('/*', acl.allow('Write'), del)
+  router.copy('/*', allow('Write'), copy)
+  router.get('/*', index, allow('Read'), get)
+  router.post('/*', allow('Append'), post)
+  router.patch('/*', allow('Write'), patch)
+  router.put('/*', allow('Write'), put)
+  router.delete('/*', allow('Write'), del)
 
   return router
 }

--- a/lib/requests/auth-request.js
+++ b/lib/requests/auth-request.js
@@ -155,7 +155,6 @@ class AuthRequest {
     debug('Initializing user session with webId: ', userAccount.webId)
 
     session.userId = userAccount.webId
-    session.identified = true
     session.subject = {
       _id: userAccount.webId
     }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "node-forge": "^0.6.38",
     "nodemailer": "^3.1.4",
     "nomnom": "^1.8.1",
-    "oidc-auth-manager": "^0.7.2",
+    "oidc-auth-manager": "^0.7.3",
     "oidc-op-express": "^0.0.3",
     "rdflib": "^0.15.0",
     "recursive-readdir": "^2.1.0",

--- a/test/integration/params.js
+++ b/test/integration/params.js
@@ -97,7 +97,7 @@ describe('LDNODE params', function () {
     })
   })
 
-  describe('forcedUser', function () {
+  describe('forceUser', function () {
     var ldpHttpsServer
 
     const port = 7777
@@ -107,6 +107,7 @@ describe('LDNODE params', function () {
     const configPath = path.join(rootPath, 'config')
 
     var ldp = ldnode.createServer({
+      auth: 'tls',
       forceUser: 'https://fakeaccount.com/profile#me',
       dbPath,
       configPath,
@@ -116,7 +117,8 @@ describe('LDNODE params', function () {
       sslKey: path.join(__dirname, '../keys/key.pem'),
       sslCert: path.join(__dirname, '../keys/cert.pem'),
       webid: true,
-      host: 'localhost:3457'
+      host: 'localhost:3457',
+      rejectUnauthorized: false
     })
 
     before(function (done) {
@@ -131,7 +133,7 @@ describe('LDNODE params', function () {
 
     var server = supertest(serverUri)
 
-    it('should find resource in correct path', function (done) {
+    it('sets the User header', function (done) {
       server.get('/hello.html')
         .expect('User', 'https://fakeaccount.com/profile#me')
         .end(done)

--- a/test/unit/acl-checker.js
+++ b/test/unit/acl-checker.js
@@ -1,15 +1,13 @@
 'use strict'
 const proxyquire = require('proxyquire')
 const chai = require('chai')
-const { assert, expect } = chai
+const { assert } = chai
 const dirtyChai = require('dirty-chai')
 chai.use(dirtyChai)
-const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 chai.use(sinonChai)
 chai.should()
 const debug = require('../../lib/debug').ACL
-const { userIdFromRequest } = require('../../lib/handlers/allow')
 
 class PermissionSetAlwaysGrant {
   checkAccess () {
@@ -26,44 +24,6 @@ class PermissionSetAlwaysError {
     return Promise.reject(new Error('Error thrown during checkAccess()'))
   }
 }
-
-describe('Allow handler', () => {
-  let req
-  let aliceWebId = 'https://alice.example.com/#me'
-
-  beforeEach(() => {
-    req = { app: { locals: {} }, session: {} }
-  })
-
-  describe('userIdFromRequest()', () => {
-    it('should first look in session.userId', () => {
-      req.session.userId = aliceWebId
-
-      let userId = userIdFromRequest(req)
-
-      expect(userId).to.equal(aliceWebId)
-    })
-
-    it('should use webIdFromClaims() if applicable', () => {
-      req.app.locals.authMethod = 'oidc'
-      req.claims = {}
-
-      let webIdFromClaims = sinon.stub().returns(aliceWebId)
-      req.app.locals.oidc = { webIdFromClaims }
-
-      let userId = userIdFromRequest(req)
-
-      expect(userId).to.equal(aliceWebId)
-      expect(webIdFromClaims).to.have.been.calledWith(req.claims)
-    })
-
-    it('should return falsy if all else fails', () => {
-      let userId = userIdFromRequest(req)
-
-      expect(userId).to.not.be.ok()
-    })
-  })
-})
 
 describe('ACLChecker unit test', () => {
   it('should callback with null on grant success', done => {

--- a/test/unit/auth-request.js
+++ b/test/unit/auth-request.js
@@ -92,7 +92,6 @@ describe('AuthRequest', () => {
       request.initUserSession(alice)
 
       expect(request.session.userId).to.equal(webId)
-      expect(request.session.identified).to.be.true()
       let subject = request.session.subject
       expect(subject['_id']).to.equal(webId)
     })

--- a/test/unit/force-user.js
+++ b/test/unit/force-user.js
@@ -1,0 +1,70 @@
+const forceUser = require('../../lib/api/authn/force-user')
+const sinon = require('sinon')
+const chai = require('chai')
+const { expect } = chai
+const sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+
+const USER = 'https://ruben.verborgh.org/profile/#me'
+
+describe('Force User', () => {
+  describe('a forceUser handler', () => {
+    let app, handler
+    before(() => {
+      app = { use: sinon.stub() }
+      const argv = { forceUser: USER }
+      forceUser.initialize(app, argv)
+      handler = app.use.getCall(0).args[1]
+    })
+
+    it('adds a route on /', () => {
+      expect(app.use).to.have.callCount(1)
+      expect(app.use).to.have.been.calledWith('/')
+    })
+
+    describe('when called', () => {
+      let request, response
+      before(done => {
+        request = { session: {} }
+        response = { set: sinon.stub() }
+        handler(request, response, done)
+      })
+
+      it('sets session.userId to the user', () => {
+        expect(request.session).to.have.property('userId', USER)
+      })
+
+      it('does not set the User header', () => {
+        expect(response.set).to.have.callCount(0)
+      })
+    })
+  })
+
+  describe('a forceUser handler for TLS', () => {
+    let handler
+    before(() => {
+      const app = { use: sinon.stub() }
+      const argv = { forceUser: USER, auth: 'tls' }
+      forceUser.initialize(app, argv)
+      handler = app.use.getCall(0).args[1]
+    })
+
+    describe('when called', () => {
+      let request, response
+      before(done => {
+        request = { session: {} }
+        response = { set: sinon.stub() }
+        handler(request, response, done)
+      })
+
+      it('sets session.userId to the user', () => {
+        expect(request.session).to.have.property('userId', USER)
+      })
+
+      it('sets the User header', () => {
+        expect(response.set).to.have.callCount(1)
+        expect(response.set).to.have.been.calledWith('User', USER)
+      })
+    })
+  })
+})


### PR DESCRIPTION
The current `allow.js` performs two functions:

1. obtaining the user ID
2. checking whether the user is authenticated

As a consequence, functions are currently tied sequentially.

However, it is not unthinkable that other steps need to be performed in between: other handlers might want to know the user ID without/before checking permissions on the LDP storage. (Case in point: the proxy delegation I'm working on.)

This pull request therefore splits user ID extract and ACL checking.