### PR TITLE
Add startup script for testing purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ $ solid start --root path/to/folder --port 8443 --ssl-key path/to/ssl-key.pem --
 # Solid server (solid v0.2.24) running on https://localhost:8443/
 ```
 
-##### How do I get an SSL key and certificate?
-You need an SSL certificate you get this from your domain provider or for free from [Let's Encrypt!](https://letsencrypt.org/getting-started/).
+### Running in development environments
 
-If you don't have one yet, or you just want to test `solid`, generate a certificate (**DO NOT USE IN PRODUCTION**):
+Solid requires SSL certificates to be valid, so you cannot use self-signed certificates. To switch off this security feature in development environments, you can use the `bin/solid-test` executable, which unsets the `NODE_TLS_REJECT_UNAUTHORIZED` flag. If you want to test WebID-TLS authentication with self-signed certificates, additionally set `"rejectUnauthorized": false` in `config.json`.
+
+##### How do I get an SSL key and certificate?
+You need an SSL certificate from a _certificate authority_, such as your domain provider or [Let's Encrypt!](https://letsencrypt.org/getting-started/).
+
+For testing purposes, you can use `bin/solid-test` with a _self-signed_ certificate, generated as follows:
 ```
 $ openssl genrsa 2048 > ../localhost.key
 $ openssl req -new -x509 -nodes -sha256 -days 3650 -key ../localhost.key -subj '/CN=*.localhost' > ../localhost.cert

--- a/bin/solid
+++ b/bin/solid
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+var program = require('commander')
+var packageJson = require('../package.json')
+var loadInit = require('./lib/init')
+var loadStart = require('./lib/start')
+
+program
+  .version(packageJson.version)
+
+loadInit(program)
+loadStart(program)
+
+program.parse(process.argv)
+if (program.args.length === 0) program.help()

--- a/bin/solid-test
+++ b/bin/solid-test
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 exec `dirname "$0"`/solid $@

--- a/bin/solid.js
+++ b/bin/solid.js
@@ -1,15 +1,1 @@
-#!/usr/bin/env node
-
-var program = require('commander')
-var packageJson = require('../package.json')
-var loadInit = require('./lib/init')
-var loadStart = require('./lib/start')
-
-program
-  .version(packageJson.version)
-
-loadInit(program)
-loadStart(program)
-
-program.parse(process.argv)
-if (program.args.length === 0) program.help()
+solid

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "solid": "node ./bin/solid.js",
+    "solid": "node ./bin/solid",
     "standard": "standard",
     "mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 nyc mocha ./test/**/*.js",
     "test": "npm run standard && npm run mocha",
@@ -129,7 +129,7 @@
     ]
   },
   "bin": {
-    "solid": "./bin/solid.js"
+    "solid": "./bin/solid"
   },
   "engines": {
     "node": ">=6.0"


### PR DESCRIPTION
The [security setting](https://github.com/solid/node-solid-server/pull/518/commits/293c86102277cc035807c0e5aebff5ba119dce22) associated with Node 8 compatibility (#518) means the server will only work with trusted certificates. To avoid this for testing purposes, the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable should be set.

In order to facilitate that, this pull request adds a `bin/solid-test` executable. For consistency, it also renames the default executable to `bin/solid` from `bin/solid.js`, but the latter is symlinked.

Open questions:
- [x] Is `solid-test` an appropriate name? I thought of alternatives such as `solid-insecure`, but that seemed to strong. In any case, the executable is _not_ exported in `package.json`.
- [x] Where should documentation for this feature be added? (In any case, to the changelog [#534].)