### PR TITLE
Cache APT packages on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ addons:
     - nicola.localhost
 
 cache:
+  apt: true
   directories:
     - node_modules


### PR DESCRIPTION
180a11434cbb07657216df5c930b60defd518fca added g++-4.8 on Travis. This pull request ensures it is cached in order to speed up builds.