### PR TITLE
Allow login via TLS with externally hosted WebIDs

### DIFF
--- a/default-views/auth/select-provider.hbs
+++ b/default-views/auth/select-provider.hbs
@@ -11,6 +11,13 @@
   <div>
     <h2>Select Provider</h2>
   </div>
+  {{#if error}}
+    <div class="row">
+      <div class="col-md-12">
+        <p class="text-danger"><strong>{{error}}</strong></p>
+      </div>
+    </div>
+  {{/if}}
 </div>
 <div class="container">
   <form method="post" action="/api/auth/select-provider">

--- a/lib/models/account-manager.js
+++ b/lib/models/account-manager.js
@@ -350,11 +350,11 @@ class AccountManager {
         this.accountWebIdFor(userData.username)
     }
 
-    if (!userConfig.webId && !userConfig.username) {
-      throw new Error('Username or web id is required')
-    }
+    if (!userConfig.username) {
+      if (!userConfig.webId) {
+        throw new Error('Username or web id is required')
+      }
 
-    if (userConfig.webId && !userConfig.username) {
       userConfig.username = this.usernameFromWebId(userConfig.webId)
     }
 
@@ -391,14 +391,6 @@ class AccountManager {
       .then(() => {
         return template.processAccount(accountDir)
       })
-  }
-
-  externalAccount (webId) {
-    let webIdHostname = url.parse(webId).hostname
-
-    let serverHostname = this.host.hostname
-
-    return !webIdHostname.endsWith(serverHostname)
   }
 
   /**

--- a/lib/models/account-manager.js
+++ b/lib/models/account-manager.js
@@ -345,16 +345,17 @@ class AccountManager {
       username: userData.username,
       email: userData.email,
       name: userData.name,
+      externalWebId: userData.externalWebId,
       webId: userData.webid || userData.webId ||
         this.accountWebIdFor(userData.username)
     }
 
-    if (userConfig.webId && !userConfig.username) {
-      userConfig.username = this.usernameFromWebId(userConfig.webId)
-    }
-
     if (!userConfig.webId && !userConfig.username) {
       throw new Error('Username or web id is required')
+    }
+
+    if (userConfig.webId && !userConfig.username) {
+      userConfig.username = this.usernameFromWebId(userConfig.webId)
     }
 
     return UserAccount.from(userConfig)

--- a/lib/models/authenticator.js
+++ b/lib/models/authenticator.js
@@ -3,6 +3,8 @@
 const debug = require('./../debug').authentication
 const validUrl = require('valid-url')
 const webid = require('webid/tls')
+const provider = require('oidc-auth-manager/src/preferred-provider')
+const { domainMatches } = require('oidc-auth-manager/src/oidc-manager')
 
 /**
  * Abstract Authenticator class, representing a local login strategy.
@@ -293,6 +295,10 @@ class TlsAuthenticator extends Authenticator {
     webid.verify(certificate, callback)
   }
 
+  discoverProviderFor (webId) {
+    return provider.discoverProviderFor(webId)
+  }
+
   /**
    * Ensures that the extracted WebID URI is hosted on this server. If it is,
    * returns a UserAccount instance for that WebID, throws an error otherwise.
@@ -304,13 +310,27 @@ class TlsAuthenticator extends Authenticator {
    * @return {UserAccount}
    */
   ensureLocalUser (webId) {
-    if (this.accountManager.externalAccount(webId)) {
-      debug(`WebID URI ${JSON.stringify(webId)} is not a local account`)
+    const serverUri = this.accountManager.host.serverUri
 
-      throw new Error('Cannot login: Selected Web ID is not hosted on this server')
+    // if (this.accountManager.externalAccount(webId)) {
+    if (domainMatches(serverUri, webId)) {
+      // This is a locally hosted Web ID
+      return Promise.resolve(this.accountManager.userAccountFrom({ webId }))
     }
 
-    return this.accountManager.userAccountFrom({ webId })
+    debug(`WebID URI ${JSON.stringify(webId)} is not a local account, verifying preferred provider`)
+
+    return this.discoverProviderFor(webId)
+      .then(preferredProvider => {
+        debug(`Preferred provider for ${webId} is ${preferredProvider}`)
+
+        if (preferredProvider === serverUri) {  // everything checks out
+          return this.accountManager.userAccountFrom({ webId, username: webId, externalWebId: true })
+        }
+
+        throw new Error(`This server is not the preferred provider for Web ID ${webId}`)
+      })
+    // return Promise.reject(new Error('Cannot login: Selected Web ID is not hosted on this server'))
   }
 }
 

--- a/lib/models/authenticator.js
+++ b/lib/models/authenticator.js
@@ -312,7 +312,6 @@ class TlsAuthenticator extends Authenticator {
   ensureLocalUser (webId) {
     const serverUri = this.accountManager.host.serverUri
 
-    // if (this.accountManager.externalAccount(webId)) {
     if (domainMatches(serverUri, webId)) {
       // This is a locally hosted Web ID
       return Promise.resolve(this.accountManager.userAccountFrom({ webId }))
@@ -321,16 +320,15 @@ class TlsAuthenticator extends Authenticator {
     debug(`WebID URI ${JSON.stringify(webId)} is not a local account, verifying preferred provider`)
 
     return this.discoverProviderFor(webId)
-      .then(preferredProvider => {
-        debug(`Preferred provider for ${webId} is ${preferredProvider}`)
+      .then(authorizedProvider => {
+        debug(`Authorized provider for ${webId} is ${authorizedProvider}`)
 
-        if (preferredProvider === serverUri) {  // everything checks out
+        if (authorizedProvider === serverUri) {  // everything checks out
           return this.accountManager.userAccountFrom({ webId, username: webId, externalWebId: true })
         }
 
-        throw new Error(`This server is not the preferred provider for Web ID ${webId}`)
+        throw new Error(`This server is not the authorized provider for Web ID ${webId}`)
       })
-    // return Promise.reject(new Error('Cannot login: Selected Web ID is not hosted on this server'))
   }
 }
 

--- a/lib/models/authenticator.js
+++ b/lib/models/authenticator.js
@@ -327,7 +327,8 @@ class TlsAuthenticator extends Authenticator {
           return this.accountManager.userAccountFrom({ webId, username: webId, externalWebId: true })
         }
 
-        throw new Error(`This server is not the authorized provider for Web ID ${webId}`)
+        throw new Error(`This server is not the authorized provider for Web ID ${webId}. 
+        See https://github.com/solid/webid-oidc-spec#authorized-oidc-issuer-discovery`)
       })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4873,9 +4873,9 @@
       }
     },
     "oidc-auth-manager": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/oidc-auth-manager/-/oidc-auth-manager-0.10.0.tgz",
-      "integrity": "sha512-nUASN8khRHMJ4BOYTO7fypfc2GuXd+6aDM8/WMEeyJQJakOPkIFdNV4wBXMaAlCeumWEvoEJI/BhrcZe1L0UMQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/oidc-auth-manager/-/oidc-auth-manager-0.11.1.tgz",
+      "integrity": "sha512-P83EZ/muMqwyaXvGbnTTQSzx4gPaKhhjiGH5BOSTP2Kb0mlDT1QEOMKYkDS1frUi9ZkZBppVH7zKW4dyU3rAig==",
       "requires": {
         "@trust/oidc-op": "0.3.0",
         "@trust/oidc-rs": "0.2.1",
@@ -4885,10 +4885,16 @@
         "li": "1.2.1",
         "node-fetch": "1.7.2",
         "node-mocks-http": "1.6.4",
-        "solid-multi-rp-client": "0.2.0",
+        "rdflib": "0.16.2",
+        "solid-multi-rp-client": "0.2.1",
         "valid-url": "1.0.9"
       },
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
         "fs-extra": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
@@ -4906,6 +4912,32 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
+        },
+        "rdflib": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-0.16.2.tgz",
+          "integrity": "sha1-IAzOwaZxAQIVr5bp5s187eKyGrU=",
+          "requires": {
+            "async": "0.9.2",
+            "jsonld": "0.4.12",
+            "n3": "0.4.5",
+            "node-fetch": "1.7.2",
+            "xmldom": "0.1.27"
+          }
+        },
+        "solid-multi-rp-client": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/solid-multi-rp-client/-/solid-multi-rp-client-0.2.1.tgz",
+          "integrity": "sha1-NGinUYjv6KpfTE5+wUQ6cbgy0AM=",
+          "requires": {
+            "@trust/oidc-rp": "0.4.1",
+            "kvplus-files": "0.0.4"
+          }
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+          "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
         }
       }
     },
@@ -5774,15 +5806,6 @@
       "dev": true,
       "requires": {
         "@trust/oidc-rp": "0.4.1"
-      }
-    },
-    "solid-multi-rp-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/solid-multi-rp-client/-/solid-multi-rp-client-0.2.0.tgz",
-      "integrity": "sha1-5T+356YcC1lVEt67S+B3EhUEJjU=",
-      "requires": {
-        "@trust/oidc-rp": "0.4.1",
-        "kvplus-files": "0.0.4"
       }
     },
     "solid-namespace": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "node-forge": "^0.6.38",
     "nodemailer": "^3.1.4",
     "nomnom": "^1.8.1",
-    "oidc-auth-manager": "^0.10.0",
+    "oidc-auth-manager": "^0.11.1",
     "oidc-op-express": "^0.0.3",
     "rdflib": "^0.15.0",
     "recursive-readdir": "^2.1.0",

--- a/test/unit/account-manager-test.js
+++ b/test/unit/account-manager-test.js
@@ -455,26 +455,4 @@ describe('AccountManager', () => {
         })
     })
   })
-
-  describe('externalAccount()', () => {
-    it('should return true if account is a subdomain of the local server url', () => {
-      let options = { host }
-
-      let accountManager = AccountManager.from(options)
-
-      let webId = 'https://alice.example.com/#me'
-
-      expect(accountManager.externalAccount(webId)).to.be.false()
-    })
-
-    it('should return false if account does not match the local server url', () => {
-      let options = { host }
-
-      let accountManager = AccountManager.from(options)
-
-      let webId = 'https://alice.databox.me/#me'
-
-      expect(accountManager.externalAccount(webId)).to.be.true()
-    })
-  })
 })

--- a/test/unit/tls-authenticator-test.js
+++ b/test/unit/tls-authenticator-test.js
@@ -134,7 +134,7 @@ describe('TlsAuthenticator', () => {
   })
 
   describe('ensureLocalUser()', () => {
-    it('should throw an error if external user and this server not the preferred provider', done => {
+    it('should throw an error if external user and this server not the authorized provider', done => {
       let tlsAuth = new TlsAuthenticator({ accountManager })
 
       let externalWebId = 'https://alice.someothersite.com#me'
@@ -143,7 +143,7 @@ describe('TlsAuthenticator', () => {
 
       tlsAuth.ensureLocalUser(externalWebId)
         .catch(err => {
-          expect(err.message).to.match(/This server is not the preferred provider for Web ID https:\/\/alice.someothersite.com#me/)
+          expect(err.message).to.match(/This server is not the authorized provider for Web ID https:\/\/alice.someothersite.com#me/)
           done()
         })
     })
@@ -160,7 +160,7 @@ describe('TlsAuthenticator', () => {
         })
     })
 
-    it('should return a user instance if external user and this server is preferred provider', () => {
+    it('should return a user instance if external user and this server is authorized provider', () => {
       let tlsAuth = new TlsAuthenticator({ accountManager })
 
       let externalWebId = 'https://alice.someothersite.com#me'


### PR DESCRIPTION
(after verifying that the server is the preferred oidc issuer of that webid profile).

Addresses https://github.com/solid/node-solid-server/issues/521