### PR TITLE
Add caching to ACL

### DIFF
--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -26,17 +26,10 @@ class ACLChecker {
 
     // Check the permissions within the nearest ACL
     return this.getNearestACL(resource)
-    .then(({ acl, graph, isContainer }) =>
-      this.checkAccess(
-        graph, // The ACL graph
-        user, // The webId of the user
-        mode, // Read/Write/Append
-        resource, // The resource we want to access
-        isContainer,
-        acl, // The current Acl file!
-        options
-      )
-    )
+    .then(nearestAcl => {
+      const acls = this.getPermissionSet(nearestAcl, resource, options)
+      return this.checkAccess(acls, user, mode, resource)
+    })
     .then(() => { debug('ACL policy found') })
     .catch(err => {
       debug(`Error: ${err.message}`)
@@ -95,32 +88,15 @@ class ACLChecker {
     return urls
   }
 
-  /**
-   * Tests whether a graph (parsed .acl resource) allows a given operation
-   * for a given user. Calls the provided callback with `null` if the user
-   * has access, otherwise calls it with an error.
-   * @method checkAccess
-   * @param graph {Graph} Parsed RDF graph of current .acl resource
-   * @param user {String} WebID URI of the user accessing the resource
-   * @param mode {String} Access mode, e.g. 'Read', 'Write', etc.
-   * @param resource {String} URI of the resource being accessed
-   * @param isContainer {boolean}
-   * @param acl {String} URI of this current .acl resource
-   * @param options {Object} Options hashmap
-   * @param [options.origin] Request's `Origin:` header
-   * @param [options.host] Request's host URI (with protocol)
-   */
-  checkAccess (graph, user, mode, resource, isContainer, acl, options = {}) {
-    const acls = this.getPermissionSet(graph, resource, isContainer, acl, options)
-
-    return acls.checkAccess(resource, user, mode)
+  // Tests whether the permissions allow a given operation
+  checkAccess (permissionSet, user, mode, resource) {
+    return permissionSet.checkAccess(resource, user, mode)
     .then(hasAccess => {
       if (hasAccess) {
         this.debug(`${mode} access permitted to ${user}`)
         return true
       } else {
-        this.debug(`${mode} access NOT permitted to ${user}` +
-          this.strictOrigin ? ` and origin ${options.origin}` : '')
+        this.debug(`${mode} access NOT permitted to ${user}`)
         throw new Error('ACL file found but no matching policy found')
       }
     })
@@ -132,7 +108,7 @@ class ACLChecker {
   }
 
   // Gets the permission set for the given resource
-  getPermissionSet (graph, resource, isContainer, acl, options = {}) {
+  getPermissionSet ({ acl, graph, isContainer }, resource, options = {}) {
     const debug = this.debug
     if (!graph || graph.length === 0) {
       debug('ACL ' + acl + ' is empty')

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -46,9 +46,8 @@ class ACLChecker {
             resource, // The resource we want to access
             accessType, // accessTo or defaultForNew
             acl, // The current Acl file!
-            (err) => { return next(!err || err) },
             options
-          )
+          ).then(next, next)
         })
       },
       function handleNoAccess (err) {
@@ -87,17 +86,14 @@ class ACLChecker {
    * @param resource {String} URI of the resource being accessed
    * @param accessType {String} One of `accessTo`, or `default`
    * @param acl {String} URI of this current .acl resource
-   * @param callback {Function}
    * @param options {Object} Options hashmap
    * @param [options.origin] Request's `Origin:` header
    * @param [options.host] Request's host URI (with protocol)
    */
-  checkAccess (graph, user, mode, resource, accessType, acl, callback,
-               options = {}) {
-    const debug = this.debug
+  checkAccess (graph, user, mode, resource, accessType, acl, options = {}) {
     if (!graph || graph.length === 0) {
       debug('ACL ' + acl + ' is empty')
-      return callback(new Error('No policy found - empty ACL'))
+      return Promise.reject(new Error('No policy found - empty ACL'))
     }
     let isContainer = accessType.startsWith('default')
     let aclOptions = {
@@ -107,26 +103,26 @@ class ACLChecker {
       origin: options.origin,
       rdf: rdf,
       strictOrigin: this.strictOrigin,
-      isAcl: (uri) => { return this.isAcl(uri) },
-      aclUrlFor: (uri) => { return this.aclUrlFor(uri) }
+      isAcl: uri => this.isAcl(uri),
+      aclUrlFor: uri => this.aclUrlFor(uri)
     }
     let acls = new PermissionSet(resource, acl, isContainer, aclOptions)
-    acls.checkAccess(resource, user, mode)
-      .then(hasAccess => {
-        if (hasAccess) {
-          debug(`${mode} access permitted to ${user}`)
-          return callback()
-        } else {
-          debug(`${mode} access NOT permitted to ${user}` +
-            aclOptions.strictOrigin ? ` and origin ${options.origin}` : '')
-          return callback(new Error('ACL file found but no matching policy found'))
-        }
-      })
-      .catch(err => {
-        debug(`${mode} access denied to ${user}`)
-        debug(err)
-        return callback(err)
-      })
+    return acls.checkAccess(resource, user, mode)
+    .then(hasAccess => {
+      if (hasAccess) {
+        this.debug(`${mode} access permitted to ${user}`)
+        return true
+      } else {
+        this.debug(`${mode} access NOT permitted to ${user}` +
+          aclOptions.strictOrigin ? ` and origin ${options.origin}` : '')
+        throw new Error('ACL file found but no matching policy found')
+      }
+    })
+    .catch(err => {
+      this.debug(`${mode} access denied to ${user}`)
+      this.debug(err)
+      throw err
+    })
   }
 
   aclUrlFor (uri) {

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -26,13 +26,13 @@ class ACLChecker {
 
     // Check the permissions within the nearest ACL
     return this.getNearestACL(resource)
-    .then(({ acl, graph, accessType }) =>
+    .then(({ acl, graph, isContainer }) =>
       this.checkAccess(
         graph, // The ACL graph
         user, // The webId of the user
         mode, // Read/Write/Append
         resource, // The resource we want to access
-        accessType, // accessTo or defaultForNew
+        isContainer,
         acl, // The current Acl file!
         options
       )
@@ -52,7 +52,7 @@ class ACLChecker {
 
   // Gets the ACL that applies to the resource
   getNearestACL (uri) {
-    let accessType = 'accessTo'
+    let isContainer = false
     let nearestACL = Promise.reject()
     for (const acl of this.getPossibleACLs(uri, this.suffix)) {
       nearestACL = nearestACL.catch(() => new Promise((resolve, reject) => {
@@ -60,10 +60,10 @@ class ACLChecker {
         this.fetch(acl, (err, graph) => {
           if (err || !graph || !graph.length) {
             if (err) this.debug(`Error reading ${acl}: ${err}`)
-            accessType = 'defaultForNew'
+            isContainer = true
             reject(err)
           } else {
-            resolve({ acl, graph, accessType })
+            resolve({ acl, graph, isContainer })
           }
         })
       }))
@@ -104,14 +104,13 @@ class ACLChecker {
    * @param user {String} WebID URI of the user accessing the resource
    * @param mode {String} Access mode, e.g. 'Read', 'Write', etc.
    * @param resource {String} URI of the resource being accessed
-   * @param accessType {String} One of `accessTo`, or `default`
+   * @param isContainer {boolean}
    * @param acl {String} URI of this current .acl resource
    * @param options {Object} Options hashmap
    * @param [options.origin] Request's `Origin:` header
    * @param [options.host] Request's host URI (with protocol)
    */
-  checkAccess (graph, user, mode, resource, accessType, acl, options = {}) {
-    const isContainer = accessType.startsWith('default')
+  checkAccess (graph, user, mode, resource, isContainer, acl, options = {}) {
     const acls = this.getPermissionSet(graph, resource, isContainer, acl, options)
 
     return acls.checkAccess(resource, user, mode)

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -4,25 +4,26 @@ const path = require('path')
 const PermissionSet = require('solid-permissions').PermissionSet
 const rdf = require('rdflib')
 const url = require('url')
+const debug = require('./debug').ACL
 const HTTPError = require('./http-error')
 
 const DEFAULT_ACL_SUFFIX = '.acl'
 
+// An ACLChecker exposes the permissions on a specific resource
 class ACLChecker {
   constructor (resource, options = {}) {
     this.resource = resource
     this.host = options.host
     this.origin = options.origin
-    this.debug = options.debug || console.log.bind(console)
     this.fetch = options.fetch
     this.strictOrigin = options.strictOrigin
     this.suffix = options.suffix || DEFAULT_ACL_SUFFIX
   }
 
   // Returns a fulfilled promise when the user can access the resource
-  // in the given mode, or a rejected promise otherwise
+  // in the given mode, or rejects with an HTTP error otherwise
   can (user, mode) {
-    this.debug(`Can ${user || 'an agent'} ${mode} ${this.resource}?`)
+    debug(`Can ${user || 'an agent'} ${mode} ${this.resource}?`)
     // If this is an ACL, Control mode must be present for any operations
     if (this.isAcl(this.resource)) {
       mode = 'Control'
@@ -34,16 +35,15 @@ class ACLChecker {
         .then(acl => this.getPermissionSet(acl))
     }
 
-    // Check the permissions
+    // Check the resource's permissions
     return this._permissionSet.then(acls => this.checkAccess(acls, user, mode))
-    .then(() => { this.debug('ACL policy found') })
     .catch(err => {
-      this.debug(`Error: ${err.message}`)
+      debug(`Error: ${err.message}`)
       if (!user) {
-        this.debug('Authentication required')
+        debug('Authentication required')
         throw new HTTPError(401, `Access to ${this.resource} requires authorization`)
       } else {
-        this.debug(`${mode} access denied for ${user}`)
+        debug(`${mode} access denied for ${user}`)
         throw new HTTPError(403, `Access to ${this.resource} denied for ${user}`)
       }
     })
@@ -52,13 +52,14 @@ class ACLChecker {
   // Gets the ACL that applies to the resource
   getNearestACL () {
     let isContainer = false
+    // Create a cascade of reject handlers (one for each possible ACL)
     let nearestACL = Promise.reject()
     for (const acl of this.getPossibleACLs()) {
       nearestACL = nearestACL.catch(() => new Promise((resolve, reject) => {
-        this.debug(`Check if ACL exists: ${acl}`)
+        debug(`Check if ACL exists: ${acl}`)
         this.fetch(acl, (err, graph) => {
           if (err || !graph || !graph.length) {
-            if (err) this.debug(`Error reading ${acl}: ${err}`)
+            if (err) debug(`Error reading ${acl}: ${err}`)
             isContainer = true
             reject(err)
           } else {
@@ -70,26 +71,26 @@ class ACLChecker {
     return nearestACL.catch(e => { throw new Error('No ACL resource found') })
   }
 
-  // Get all possible ACL paths that apply to the resource
+  // Gets all possible ACL paths that apply to the resource
   getPossibleACLs () {
-    var uri = this.resource
-    var suffix = this.suffix
-    var first = uri.endsWith(suffix) ? uri : uri + suffix
-    var urls = [first]
-    var parsedUri = url.parse(uri)
-    var baseUrl = (parsedUri.protocol ? parsedUri.protocol + '//' : '') +
+    let uri = this.resource
+    const suffix = this.suffix
+    const first = uri.endsWith(suffix) ? uri : uri + suffix
+    const urls = [first]
+    const parsedUri = url.parse(uri)
+    const baseUrl = (parsedUri.protocol ? parsedUri.protocol + '//' : '') +
       (parsedUri.host || '')
     if (baseUrl + '/' === uri) {
       return urls
     }
 
-    var times = parsedUri.pathname.split('/').length
+    let times = parsedUri.pathname.split('/').length
     // TODO: improve temporary solution to stop recursive path walking above root
     if (parsedUri.pathname.endsWith('/')) {
       times--
     }
 
-    for (var i = 0; i < times - 1; i++) {
+    for (let i = 0; i < times - 1; i++) {
       uri = path.dirname(uri)
       urls.push(uri + (uri[uri.length - 1] === '/' ? suffix : '/' + suffix))
     }
@@ -101,23 +102,22 @@ class ACLChecker {
     return permissionSet.checkAccess(this.resource, user, mode)
     .then(hasAccess => {
       if (hasAccess) {
-        this.debug(`${mode} access permitted to ${user}`)
+        debug(`${mode} access permitted to ${user}`)
         return true
       } else {
-        this.debug(`${mode} access NOT permitted to ${user}`)
+        debug(`${mode} access NOT permitted to ${user}`)
         throw new Error('ACL file found but no matching policy found')
       }
     })
     .catch(err => {
-      this.debug(`${mode} access denied to ${user}`)
-      this.debug(err)
+      debug(`${mode} access denied to ${user}`)
+      debug(err)
       throw err
     })
   }
 
   // Gets the permission set for the given ACL
   getPermissionSet ({ acl, graph, isContainer }) {
-    const debug = this.debug
     if (!graph || graph.length === 0) {
       debug('ACL ' + acl + ' is empty')
       throw new Error('No policy found - empty ACL')
@@ -136,19 +136,11 @@ class ACLChecker {
   }
 
   aclUrlFor (uri) {
-    if (this.isAcl(uri)) {
-      return uri
-    } else {
-      return uri + this.suffix
-    }
+    return this.isAcl(uri) ? uri : uri + this.suffix
   }
 
   isAcl (resource) {
-    if (typeof resource === 'string') {
-      return resource.endsWith(this.suffix)
-    } else {
-      return false
-    }
+    return resource.endsWith(this.suffix)
   }
 }
 

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -11,13 +11,15 @@ const DEFAULT_ACL_SUFFIX = '.acl'
 class ACLChecker {
   constructor (resource, options = {}) {
     this.resource = resource
+    this.host = options.host
+    this.origin = options.origin
     this.debug = options.debug || console.log.bind(console)
     this.fetch = options.fetch
     this.strictOrigin = options.strictOrigin
     this.suffix = options.suffix || DEFAULT_ACL_SUFFIX
   }
 
-  can (user, mode, options = {}) {
+  can (user, mode) {
     const debug = this.debug
     this.debug(`Can ${user || 'an agent'} ${mode} ${this.resource}?`)
     // If this is an ACL, Control mode must be present for any operations
@@ -28,7 +30,7 @@ class ACLChecker {
     // Check the permissions within the nearest ACL
     return this.getNearestACL(this.resource)
     .then(nearestAcl => {
-      const acls = this.getPermissionSet(nearestAcl, options)
+      const acls = this.getPermissionSet(nearestAcl)
       return this.checkAccess(acls, user, mode, this.resource)
     })
     .then(() => { debug('ACL policy found') })
@@ -111,7 +113,7 @@ class ACLChecker {
   }
 
   // Gets the permission set for the given resource
-  getPermissionSet ({ acl, graph, isContainer }, options = {}) {
+  getPermissionSet ({ acl, graph, isContainer }) {
     const debug = this.debug
     if (!graph || graph.length === 0) {
       debug('ACL ' + acl + ' is empty')
@@ -120,8 +122,8 @@ class ACLChecker {
     const aclOptions = {
       aclSuffix: this.suffix,
       graph: graph,
-      host: options.host,
-      origin: options.origin,
+      host: this.host,
+      origin: this.origin,
       rdf: rdf,
       strictOrigin: this.strictOrigin,
       isAcl: uri => this.isAcl(uri),

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -9,33 +9,34 @@ const HTTPError = require('./http-error')
 const DEFAULT_ACL_SUFFIX = '.acl'
 
 class ACLChecker {
-  constructor (options = {}) {
+  constructor (resource, options = {}) {
+    this.resource = resource
     this.debug = options.debug || console.log.bind(console)
     this.fetch = options.fetch
     this.strictOrigin = options.strictOrigin
     this.suffix = options.suffix || DEFAULT_ACL_SUFFIX
   }
 
-  can (user, mode, resource, options = {}) {
+  can (user, mode, options = {}) {
     const debug = this.debug
-    debug('Can ' + (user || 'an agent') + ' ' + mode + ' ' + resource + '?')
+    this.debug(`Can ${user || 'an agent'} ${mode} ${this.resource}?`)
     // If this is an ACL, Control mode must be present for any operations
-    if (this.isAcl(resource)) {
+    if (this.isAcl(this.resource)) {
       mode = 'Control'
     }
 
     // Check the permissions within the nearest ACL
-    return this.getNearestACL(resource)
+    return this.getNearestACL(this.resource)
     .then(nearestAcl => {
-      const acls = this.getPermissionSet(nearestAcl, resource, options)
-      return this.checkAccess(acls, user, mode, resource)
+      const acls = this.getPermissionSet(nearestAcl, options)
+      return this.checkAccess(acls, user, mode, this.resource)
     })
     .then(() => { debug('ACL policy found') })
     .catch(err => {
       debug(`Error: ${err.message}`)
       if (!user) {
         debug('Authentication required')
-        throw new HTTPError(401, `Access to ${resource} requires authorization`)
+        throw new HTTPError(401, `Access to ${this.resource} requires authorization`)
       } else {
         debug(`${mode} access denied for ${user}`)
         throw new HTTPError(403, `Access denied for ${user}`)
@@ -44,10 +45,10 @@ class ACLChecker {
   }
 
   // Gets the ACL that applies to the resource
-  getNearestACL (uri) {
+  getNearestACL () {
     let isContainer = false
     let nearestACL = Promise.reject()
-    for (const acl of this.getPossibleACLs(uri, this.suffix)) {
+    for (const acl of this.getPossibleACLs()) {
       nearestACL = nearestACL.catch(() => new Promise((resolve, reject) => {
         this.debug(`Check if ACL exists: ${acl}`)
         this.fetch(acl, (err, graph) => {
@@ -65,7 +66,9 @@ class ACLChecker {
   }
 
   // Get all possible ACL paths that apply to the resource
-  getPossibleACLs (uri, suffix) {
+  getPossibleACLs () {
+    var uri = this.resource
+    var suffix = this.suffix
     var first = uri.endsWith(suffix) ? uri : uri + suffix
     var urls = [first]
     var parsedUri = url.parse(uri)
@@ -89,8 +92,8 @@ class ACLChecker {
   }
 
   // Tests whether the permissions allow a given operation
-  checkAccess (permissionSet, user, mode, resource) {
-    return permissionSet.checkAccess(resource, user, mode)
+  checkAccess (permissionSet, user, mode) {
+    return permissionSet.checkAccess(this.resource, user, mode)
     .then(hasAccess => {
       if (hasAccess) {
         this.debug(`${mode} access permitted to ${user}`)
@@ -108,7 +111,7 @@ class ACLChecker {
   }
 
   // Gets the permission set for the given resource
-  getPermissionSet ({ acl, graph, isContainer }, resource, options = {}) {
+  getPermissionSet ({ acl, graph, isContainer }, options = {}) {
     const debug = this.debug
     if (!graph || graph.length === 0) {
       debug('ACL ' + acl + ' is empty')
@@ -124,7 +127,7 @@ class ACLChecker {
       isAcl: uri => this.isAcl(uri),
       aclUrlFor: uri => this.aclUrlFor(uri)
     }
-    return new PermissionSet(resource, acl, isContainer, aclOptions)
+    return new PermissionSet(this.resource, acl, isContainer, aclOptions)
   }
 
   aclUrlFor (uri) {

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -34,17 +34,18 @@ class ACLChecker {
     }
 
     // Check the resource's permissions
-    return this._permissionSet.then(acls => this.checkAccess(acls, user, mode))
-    .catch(err => {
-      debug(`Error: ${err.message}`)
-      if (!user) {
-        debug('Authentication required')
-        throw new HTTPError(401, `Access to ${this.resource} requires authorization`)
-      } else {
-        debug(`${mode} access denied for ${user}`)
-        throw new HTTPError(403, `Access to ${this.resource} denied for ${user}`)
-      }
-    })
+    return this._permissionSet
+      .then(acls => this.checkAccess(acls, user, mode))
+      .catch(err => {
+        debug(`Error: ${err.message}`)
+        if (!user) {
+          debug('Authentication required')
+          throw new HTTPError(401, `Access to ${this.resource} requires authorization`)
+        } else {
+          debug(`${mode} access denied for ${user}`)
+          throw new HTTPError(403, `Access to ${this.resource} denied for ${user}`)
+        }
+      })
   }
 
   // Gets the ACL that applies to the resource
@@ -91,20 +92,20 @@ class ACLChecker {
   // Tests whether the permissions allow a given operation
   checkAccess (permissionSet, user, mode) {
     return permissionSet.checkAccess(this.resource, user, mode)
-    .then(hasAccess => {
-      if (hasAccess) {
-        debug(`${mode} access permitted to ${user}`)
-        return true
-      } else {
-        debug(`${mode} access NOT permitted to ${user}`)
-        throw new Error('ACL file found but no matching policy found')
-      }
-    })
-    .catch(err => {
-      debug(`${mode} access denied to ${user}`)
-      debug(err)
-      throw err
-    })
+      .then(hasAccess => {
+        if (hasAccess) {
+          debug(`${mode} access permitted to ${user}`)
+          return true
+        } else {
+          debug(`${mode} access NOT permitted to ${user}`)
+          throw new Error('ACL file found but no matching policy found')
+        }
+      })
+      .catch(err => {
+        debug(`${mode} access denied to ${user}`)
+        debug(err)
+        throw err
+      })
   }
 
   // Gets the permission set for the given ACL

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const path = require('path')
 const PermissionSet = require('solid-permissions').PermissionSet
 const rdf = require('rdflib')
-const url = require('url')
 const debug = require('./debug').ACL
 const HTTPError = require('./http-error')
 
@@ -73,28 +71,21 @@ class ACLChecker {
 
   // Gets all possible ACL paths that apply to the resource
   getPossibleACLs () {
-    let uri = this.resource
-    const suffix = this.suffix
-    const first = uri.endsWith(suffix) ? uri : uri + suffix
-    const urls = [first]
-    const parsedUri = url.parse(uri)
-    const baseUrl = (parsedUri.protocol ? parsedUri.protocol + '//' : '') +
-      (parsedUri.host || '')
-    if (baseUrl + '/' === uri) {
-      return urls
+    // Obtain the resource URI and the length of its base
+    let { resource: uri, suffix } = this
+    const [ { length: base } ] = uri.match(/^[^:]+:\/*[^/]+/)
+
+    // If the URI points to a file, append the file's ACL
+    const possibleAcls = []
+    if (!uri.endsWith('/')) {
+      possibleAcls.push(uri.endsWith(suffix) ? uri : uri + suffix)
     }
 
-    let times = parsedUri.pathname.split('/').length
-    // TODO: improve temporary solution to stop recursive path walking above root
-    if (parsedUri.pathname.endsWith('/')) {
-      times--
+    // Append the ACLs of all parent directories
+    for (let i = lastSlash(uri); i >= base; i = lastSlash(uri, i - 1)) {
+      possibleAcls.push(uri.substr(0, i + 1) + suffix)
     }
-
-    for (let i = 0; i < times - 1; i++) {
-      uri = path.dirname(uri)
-      urls.push(uri + (uri[uri.length - 1] === '/' ? suffix : '/' + suffix))
-    }
-    return urls
+    return possibleAcls
   }
 
   // Tests whether the permissions allow a given operation
@@ -142,6 +133,11 @@ class ACLChecker {
   isAcl (resource) {
     return resource.endsWith(this.suffix)
   }
+}
+
+// Returns the index of the last slash before the given position
+function lastSlash (string, pos = string.length) {
+  return string.lastIndexOf('/', pos)
 }
 
 module.exports = ACLChecker

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -19,29 +19,32 @@ class ACLChecker {
     this.suffix = options.suffix || DEFAULT_ACL_SUFFIX
   }
 
+  // Returns a fulfilled promise when the user can access the resource
+  // in the given mode, or a rejected promise otherwise
   can (user, mode) {
-    const debug = this.debug
     this.debug(`Can ${user || 'an agent'} ${mode} ${this.resource}?`)
     // If this is an ACL, Control mode must be present for any operations
     if (this.isAcl(this.resource)) {
       mode = 'Control'
     }
 
-    // Check the permissions within the nearest ACL
-    return this.getNearestACL(this.resource)
-    .then(nearestAcl => {
-      const acls = this.getPermissionSet(nearestAcl)
-      return this.checkAccess(acls, user, mode, this.resource)
-    })
-    .then(() => { debug('ACL policy found') })
+    // Obtain the permission set for the resource
+    if (!this._permissionSet) {
+      this._permissionSet = this.getNearestACL()
+        .then(acl => this.getPermissionSet(acl))
+    }
+
+    // Check the permissions
+    return this._permissionSet.then(acls => this.checkAccess(acls, user, mode))
+    .then(() => { this.debug('ACL policy found') })
     .catch(err => {
-      debug(`Error: ${err.message}`)
+      this.debug(`Error: ${err.message}`)
       if (!user) {
-        debug('Authentication required')
+        this.debug('Authentication required')
         throw new HTTPError(401, `Access to ${this.resource} requires authorization`)
       } else {
-        debug(`${mode} access denied for ${user}`)
-        throw new HTTPError(403, `Access denied for ${user}`)
+        this.debug(`${mode} access denied for ${user}`)
+        throw new HTTPError(403, `Access to ${this.resource} denied for ${user}`)
       }
     })
   }
@@ -112,7 +115,7 @@ class ACLChecker {
     })
   }
 
-  // Gets the permission set for the given resource
+  // Gets the permission set for the given ACL
   getPermissionSet ({ acl, graph, isContainer }) {
     const debug = this.debug
     if (!graph || graph.length === 0) {

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -111,12 +111,35 @@ class ACLChecker {
    * @param [options.host] Request's host URI (with protocol)
    */
   checkAccess (graph, user, mode, resource, accessType, acl, options = {}) {
+    const isContainer = accessType.startsWith('default')
+    const acls = this.getPermissionSet(graph, resource, isContainer, acl, options)
+
+    return acls.checkAccess(resource, user, mode)
+    .then(hasAccess => {
+      if (hasAccess) {
+        this.debug(`${mode} access permitted to ${user}`)
+        return true
+      } else {
+        this.debug(`${mode} access NOT permitted to ${user}` +
+          this.strictOrigin ? ` and origin ${options.origin}` : '')
+        throw new Error('ACL file found but no matching policy found')
+      }
+    })
+    .catch(err => {
+      this.debug(`${mode} access denied to ${user}`)
+      this.debug(err)
+      throw err
+    })
+  }
+
+  // Gets the permission set for the given resource
+  getPermissionSet (graph, resource, isContainer, acl, options = {}) {
+    const debug = this.debug
     if (!graph || graph.length === 0) {
       debug('ACL ' + acl + ' is empty')
-      return Promise.reject(new Error('No policy found - empty ACL'))
+      throw new Error('No policy found - empty ACL')
     }
-    let isContainer = accessType.startsWith('default')
-    let aclOptions = {
+    const aclOptions = {
       aclSuffix: this.suffix,
       graph: graph,
       host: options.host,
@@ -126,23 +149,7 @@ class ACLChecker {
       isAcl: uri => this.isAcl(uri),
       aclUrlFor: uri => this.aclUrlFor(uri)
     }
-    let acls = new PermissionSet(resource, acl, isContainer, aclOptions)
-    return acls.checkAccess(resource, user, mode)
-    .then(hasAccess => {
-      if (hasAccess) {
-        this.debug(`${mode} access permitted to ${user}`)
-        return true
-      } else {
-        this.debug(`${mode} access NOT permitted to ${user}` +
-          aclOptions.strictOrigin ? ` and origin ${options.origin}` : '')
-        throw new Error('ACL file found but no matching policy found')
-      }
-    })
-    .catch(err => {
-      this.debug(`${mode} access denied to ${user}`)
-      this.debug(err)
-      throw err
-    })
+    return new PermissionSet(resource, acl, isContainer, aclOptions)
   }
 
   aclUrlFor (uri) {

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const async = require('async')
 const path = require('path')
 const PermissionSet = require('solid-permissions').PermissionSet
 const rdf = require('rdflib')
 const url = require('url')
+const HTTPError = require('./http-error')
 
 const DEFAULT_ACL_SUFFIX = '.acl'
 
@@ -16,63 +16,58 @@ class ACLChecker {
     this.suffix = options.suffix || DEFAULT_ACL_SUFFIX
   }
 
-  can (user, mode, resource, callback, options = {}) {
+  can (user, mode, resource, options = {}) {
     const debug = this.debug
     debug('Can ' + (user || 'an agent') + ' ' + mode + ' ' + resource + '?')
-    var accessType = 'accessTo'
-    var possibleACLs = ACLChecker.possibleACLs(resource, this.suffix)
     // If this is an ACL, Control mode must be present for any operations
     if (this.isAcl(resource)) {
       mode = 'Control'
     }
-    var self = this
-    async.eachSeries(
-      possibleACLs,
 
-      // Looks for ACL, if found, looks for a rule
-      function tryAcl (acl, next) {
+    // Find nearest ACL
+    let accessType = 'accessTo'
+    let nearestACL = Promise.reject()
+    for (const acl of ACLChecker.possibleACLs(resource, this.suffix)) {
+      nearestACL = nearestACL.catch(() => new Promise((resolve, reject) => {
         debug('Check if acl exist: ' + acl)
-        // Let's see if there is a file..
-        self.fetch(acl, function (err, graph) {
-          if (err || !graph || graph.length === 0) {
-            if (err) debug('Error: ' + err)
+        this.fetch(acl, function (err, graph) {
+          if (err || !graph || !graph.length) {
+            if (err) debug(`Error reading ${acl}: ${err}`)
             accessType = 'defaultForNew'
-            return next()
-          }
-          self.checkAccess(
-            graph, // The ACL graph
-            user, // The webId of the user
-            mode, // Read/Write/Append
-            resource, // The resource we want to access
-            accessType, // accessTo or defaultForNew
-            acl, // The current Acl file!
-            options
-          ).then(next, next)
-        })
-      },
-      function handleNoAccess (err) {
-        if (err === false || err === null) {
-          debug('No ACL resource found - access not allowed')
-          err = new Error('No Access Control Policy found')
-        }
-        if (err === true) {
-          debug('ACL policy found')
-          err = null
-        }
-        if (err) {
-          debug('Error: ' + err.message)
-          if (!user || user.length === 0) {
-            debug('Authentication required')
-            err.status = 401
-            err.message = 'Access to ' + resource + ' requires authorization'
+            reject(err)
           } else {
-            debug(mode + ' access denied for: ' + user)
-            err.status = 403
-            err.message = 'Access denied for ' + user
+            resolve({ acl, graph })
           }
-        }
-        return callback(err)
-      })
+        })
+      }))
+    }
+    nearestACL = nearestACL.catch(() => {
+      throw new Error('No ACL resource found')
+    })
+
+    // Check the permissions within the ACL
+    return nearestACL.then(({ acl, graph }) =>
+      this.checkAccess(
+        graph, // The ACL graph
+        user, // The webId of the user
+        mode, // Read/Write/Append
+        resource, // The resource we want to access
+        accessType, // accessTo or defaultForNew
+        acl, // The current Acl file!
+        options
+      )
+    )
+    .then(() => { debug('ACL policy found') })
+    .catch(err => {
+      debug(`Error: ${err.message}`)
+      if (!user) {
+        debug('Authentication required')
+        throw new HTTPError(401, `Access to ${resource} requires authorization`)
+      } else {
+        debug(`${mode} access denied for ${user}`)
+        throw new HTTPError(403, `Access denied for ${user}`)
+      }
+    })
   }
 
   /**

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -24,29 +24,9 @@ class ACLChecker {
       mode = 'Control'
     }
 
-    // Find nearest ACL
-    let accessType = 'accessTo'
-    let nearestACL = Promise.reject()
-    for (const acl of ACLChecker.possibleACLs(resource, this.suffix)) {
-      nearestACL = nearestACL.catch(() => new Promise((resolve, reject) => {
-        debug('Check if acl exist: ' + acl)
-        this.fetch(acl, function (err, graph) {
-          if (err || !graph || !graph.length) {
-            if (err) debug(`Error reading ${acl}: ${err}`)
-            accessType = 'defaultForNew'
-            reject(err)
-          } else {
-            resolve({ acl, graph })
-          }
-        })
-      }))
-    }
-    nearestACL = nearestACL.catch(() => {
-      throw new Error('No ACL resource found')
-    })
-
-    // Check the permissions within the ACL
-    return nearestACL.then(({ acl, graph }) =>
+    // Check the permissions within the nearest ACL
+    return this.getNearestACL(resource)
+    .then(({ acl, graph, accessType }) =>
       this.checkAccess(
         graph, // The ACL graph
         user, // The webId of the user
@@ -68,6 +48,51 @@ class ACLChecker {
         throw new HTTPError(403, `Access denied for ${user}`)
       }
     })
+  }
+
+  // Gets the ACL that applies to the resource
+  getNearestACL (uri) {
+    let accessType = 'accessTo'
+    let nearestACL = Promise.reject()
+    for (const acl of this.getPossibleACLs(uri, this.suffix)) {
+      nearestACL = nearestACL.catch(() => new Promise((resolve, reject) => {
+        this.debug(`Check if ACL exists: ${acl}`)
+        this.fetch(acl, (err, graph) => {
+          if (err || !graph || !graph.length) {
+            if (err) this.debug(`Error reading ${acl}: ${err}`)
+            accessType = 'defaultForNew'
+            reject(err)
+          } else {
+            resolve({ acl, graph, accessType })
+          }
+        })
+      }))
+    }
+    return nearestACL.catch(e => { throw new Error('No ACL resource found') })
+  }
+
+  // Get all possible ACL paths that apply to the resource
+  getPossibleACLs (uri, suffix) {
+    var first = uri.endsWith(suffix) ? uri : uri + suffix
+    var urls = [first]
+    var parsedUri = url.parse(uri)
+    var baseUrl = (parsedUri.protocol ? parsedUri.protocol + '//' : '') +
+      (parsedUri.host || '')
+    if (baseUrl + '/' === uri) {
+      return urls
+    }
+
+    var times = parsedUri.pathname.split('/').length
+    // TODO: improve temporary solution to stop recursive path walking above root
+    if (parsedUri.pathname.endsWith('/')) {
+      times--
+    }
+
+    for (var i = 0; i < times - 1; i++) {
+      uri = path.dirname(uri)
+      urls.push(uri + (uri[uri.length - 1] === '/' ? suffix : '/' + suffix))
+    }
+    return urls
   }
 
   /**
@@ -134,29 +159,6 @@ class ACLChecker {
     } else {
       return false
     }
-  }
-
-  static possibleACLs (uri, suffix) {
-    var first = uri.endsWith(suffix) ? uri : uri + suffix
-    var urls = [first]
-    var parsedUri = url.parse(uri)
-    var baseUrl = (parsedUri.protocol ? parsedUri.protocol + '//' : '') +
-      (parsedUri.host || '')
-    if (baseUrl + '/' === uri) {
-      return urls
-    }
-
-    var times = parsedUri.pathname.split('/').length
-    // TODO: improve temporary solution to stop recursive path walking above root
-    if (parsedUri.pathname.endsWith('/')) {
-      times--
-    }
-
-    for (var i = 0; i < times - 1; i++) {
-      uri = path.dirname(uri)
-      urls.push(uri + (uri[uri.length - 1] === '/' ? suffix : '/' + suffix))
-    }
-    return urls
   }
 }
 

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -4,7 +4,6 @@ var ACL = require('../acl-checker')
 var $rdf = require('rdflib')
 var url = require('url')
 var async = require('async')
-var debug = require('../debug').ACL
 var utils = require('../utils')
 
 function allow (mode) {
@@ -14,29 +13,32 @@ function allow (mode) {
       return next()
     }
 
+    // Determine the actual path of the request
     var reqPath = res && res.locals && res.locals.path
       ? res.locals.path
       : req.path
+
+    // Check whether the resource exists
     ldp.exists(req.hostname, reqPath, (err, ret) => {
-      if (ret) {
-        var stat = ret.stream
-      }
-      if (!reqPath.endsWith('/') && !err && stat.isDirectory()) {
+      // Ensure directories always end in a slash
+      const stat = err ? null : ret.stream
+      if (!reqPath.endsWith('/') && stat && stat.isDirectory()) {
         reqPath += '/'
       }
 
-      var baseUri = utils.uriBase(req)
-      var acl = new ACL(baseUri + reqPath, {
+      // Obtain and store the ACL of the requested resource
+      const baseUri = utils.uriBase(req)
+      req.acl = new ACL(baseUri + reqPath, {
         origin: req.get('origin'),
         host: req.protocol + '://' + req.get('host'),
-        debug: debug,
         fetch: fetchDocument(req.hostname, ldp, baseUri),
         suffix: ldp.suffixAcl,
         strictOrigin: ldp.strictOrigin
       })
-      req.acl = acl
 
-      acl.can(req.session.userId, mode).then(next, next)
+      // Ensure the user has the required permission
+      req.acl.can(req.session.userId, mode)
+             .then(() => next(), next)
     })
   }
 }

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -13,15 +13,6 @@ function allow (mode) {
     if (!ldp.webid) {
       return next()
     }
-    var baseUri = utils.uriBase(req)
-
-    var acl = new ACL({
-      debug: debug,
-      fetch: fetchDocument(req.hostname, ldp, baseUri),
-      suffix: ldp.suffixAcl,
-      strictOrigin: ldp.strictOrigin
-    })
-    req.acl = acl
 
     var reqPath = res && res.locals && res.locals.path
       ? res.locals.path
@@ -37,8 +28,17 @@ function allow (mode) {
         origin: req.get('origin'),
         host: req.protocol + '://' + req.get('host')
       }
-      acl.can(req.session.userId, mode, baseUri + reqPath, options)
-      .then(next, next)
+
+      var baseUri = utils.uriBase(req)
+      var acl = new ACL(baseUri + reqPath, {
+        debug: debug,
+        fetch: fetchDocument(req.hostname, ldp, baseUri),
+        suffix: ldp.suffixAcl,
+        strictOrigin: ldp.strictOrigin
+      })
+      req.acl = acl
+
+      acl.can(req.session.userId, mode, options).then(next, next)
     })
   }
 }

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -37,7 +37,8 @@ function allow (mode) {
         origin: req.get('origin'),
         host: req.protocol + '://' + req.get('host')
       }
-      return acl.can(req.session.userId, mode, baseUri + reqPath, next, options)
+      acl.can(req.session.userId, mode, baseUri + reqPath, options)
+      .then(next, next)
     })
   }
 }

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -24,13 +24,11 @@ function allow (mode) {
       if (!reqPath.endsWith('/') && !err && stat.isDirectory()) {
         reqPath += '/'
       }
-      var options = {
-        origin: req.get('origin'),
-        host: req.protocol + '://' + req.get('host')
-      }
 
       var baseUri = utils.uriBase(req)
       var acl = new ACL(baseUri + reqPath, {
+        origin: req.get('origin'),
+        host: req.protocol + '://' + req.get('host'),
         debug: debug,
         fetch: fetchDocument(req.hostname, ldp, baseUri),
         suffix: ldp.suffixAcl,
@@ -38,7 +36,7 @@ function allow (mode) {
       })
       req.acl = acl
 
-      acl.can(req.session.userId, mode, options).then(next, next)
+      acl.can(req.session.userId, mode).then(next, next)
     })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1864,16 +1864,6 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
-    "fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true,
-      "requires": {
-        "is-object": "1.0.1",
-        "merge-descriptors": "1.0.1"
-      }
-    },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
@@ -2678,12 +2668,6 @@
         "kind-of": "3.2.2"
       }
     },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
-    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -3281,12 +3265,6 @@
           }
         }
       }
-    },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
-      "dev": true
     },
     "moment": {
       "version": "2.18.1",
@@ -5256,25 +5234,6 @@
       "requires": {
         "forwarded": "0.1.0",
         "ipaddr.js": "1.4.0"
-      }
-    },
-    "proxyquire": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
-      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
-      "dev": true,
-      "requires": {
-        "fill-keys": "1.0.2",
-        "module-not-found-error": "1.0.1",
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
       }
     },
     "public-encrypt": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "nock": "^9.0.14",
     "node-mocks-http": "^1.5.6",
     "nyc": "^10.1.2",
-    "proxyquire": "^1.7.10",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "solid-auth-oidc": "^0.2.0",

--- a/test/unit/acl-checker-test.js
+++ b/test/unit/acl-checker-test.js
@@ -27,10 +27,9 @@ describe('ACLChecker unit test', () => {
       'solid-permissions': { PermissionSet: PermissionSetAlwaysGrant }
     })
     let graph = {}
-    let accessType = ''
     let user, mode, resource, aclUrl
     let acl = new ACLChecker({ debug })
-    return expect(acl.checkAccess(graph, user, mode, resource, accessType, aclUrl))
+    return expect(acl.checkAccess(graph, user, mode, resource, true, aclUrl))
     .to.eventually.be.true
   })
   it('should callback with error on grant failure', () => {
@@ -38,10 +37,9 @@ describe('ACLChecker unit test', () => {
       'solid-permissions': { PermissionSet: PermissionSetNeverGrant }
     })
     let graph = {}
-    let accessType = ''
     let user, mode, resource, aclUrl
     let acl = new ACLChecker({ debug })
-    return expect(acl.checkAccess(graph, user, mode, resource, accessType, aclUrl))
+    return expect(acl.checkAccess(graph, user, mode, resource, true, aclUrl))
     .to.be.rejectedWith('ACL file found but no matching policy found')
   })
   it('should callback with error on grant error', () => {
@@ -49,10 +47,9 @@ describe('ACLChecker unit test', () => {
       'solid-permissions': { PermissionSet: PermissionSetAlwaysError }
     })
     let graph = {}
-    let accessType = ''
     let user, mode, resource, aclUrl
     let acl = new ACLChecker({ debug })
-    return expect(acl.checkAccess(graph, user, mode, resource, accessType, aclUrl))
+    return expect(acl.checkAccess(graph, user, mode, resource, true, aclUrl))
     .to.be.rejectedWith('Error thrown during checkAccess()')
   })
 })

--- a/test/unit/acl-checker-test.js
+++ b/test/unit/acl-checker-test.js
@@ -29,7 +29,8 @@ describe('ACLChecker unit test', () => {
     let graph = {}
     let user, mode, resource, aclUrl
     let acl = new ACLChecker({ debug })
-    return expect(acl.checkAccess(graph, user, mode, resource, true, aclUrl))
+    let acls = acl.getPermissionSet({ graph, acl: aclUrl }, resource)
+    return expect(acl.checkAccess(acls, user, mode, resource))
     .to.eventually.be.true
   })
   it('should callback with error on grant failure', () => {
@@ -39,7 +40,8 @@ describe('ACLChecker unit test', () => {
     let graph = {}
     let user, mode, resource, aclUrl
     let acl = new ACLChecker({ debug })
-    return expect(acl.checkAccess(graph, user, mode, resource, true, aclUrl))
+    let acls = acl.getPermissionSet({ graph, acl: aclUrl }, resource)
+    return expect(acl.checkAccess(acls, user, mode, resource))
     .to.be.rejectedWith('ACL file found but no matching policy found')
   })
   it('should callback with error on grant error', () => {
@@ -49,7 +51,8 @@ describe('ACLChecker unit test', () => {
     let graph = {}
     let user, mode, resource, aclUrl
     let acl = new ACLChecker({ debug })
-    return expect(acl.checkAccess(graph, user, mode, resource, true, aclUrl))
+    let acls = acl.getPermissionSet({ graph, acl: aclUrl }, resource)
+    return expect(acl.checkAccess(acls, user, mode, resource))
     .to.be.rejectedWith('Error thrown during checkAccess()')
   })
 })

--- a/test/unit/acl-checker-test.js
+++ b/test/unit/acl-checker-test.js
@@ -28,9 +28,9 @@ describe('ACLChecker unit test', () => {
     })
     let graph = {}
     let user, mode, resource, aclUrl
-    let acl = new ACLChecker({ debug })
-    let acls = acl.getPermissionSet({ graph, acl: aclUrl }, resource)
-    return expect(acl.checkAccess(acls, user, mode, resource))
+    let acl = new ACLChecker(resource, { debug })
+    let acls = acl.getPermissionSet({ graph, acl: aclUrl })
+    return expect(acl.checkAccess(acls, user, mode))
     .to.eventually.be.true
   })
   it('should callback with error on grant failure', () => {
@@ -39,9 +39,9 @@ describe('ACLChecker unit test', () => {
     })
     let graph = {}
     let user, mode, resource, aclUrl
-    let acl = new ACLChecker({ debug })
-    let acls = acl.getPermissionSet({ graph, acl: aclUrl }, resource)
-    return expect(acl.checkAccess(acls, user, mode, resource))
+    let acl = new ACLChecker(resource, { debug })
+    let acls = acl.getPermissionSet({ graph, acl: aclUrl })
+    return expect(acl.checkAccess(acls, user, mode))
     .to.be.rejectedWith('ACL file found but no matching policy found')
   })
   it('should callback with error on grant error', () => {
@@ -50,9 +50,9 @@ describe('ACLChecker unit test', () => {
     })
     let graph = {}
     let user, mode, resource, aclUrl
-    let acl = new ACLChecker({ debug })
-    let acls = acl.getPermissionSet({ graph, acl: aclUrl }, resource)
-    return expect(acl.checkAccess(acls, user, mode, resource))
+    let acl = new ACLChecker(resource, { debug })
+    let acls = acl.getPermissionSet({ graph, acl: aclUrl })
+    return expect(acl.checkAccess(acls, user, mode))
     .to.be.rejectedWith('Error thrown during checkAccess()')
   })
 })


### PR DESCRIPTION
Avoid that the same .acl files are read and parsed multiple times per request.