### PR TITLE
Expose WAC-Allow to browser clients

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -26,7 +26,7 @@ const corsSettings = cors({
   methods: [
     'OPTIONS', 'HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'
   ],
-  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, Content-Length, WWW-Authenticate',
+  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate',
   credentials: true,
   maxAge: 1728000,
   origin: true,

--- a/test/integration/header-test.js
+++ b/test/integration/header-test.js
@@ -23,17 +23,26 @@ describe('Header handler', () => {
   describe('WAC-Allow', () => {
     describeHeaderTest('read/append for the public', {
       resource: '/public-ra',
-      headers: { 'WAC-Allow': 'user="read append",public="read append"' }
+      headers: {
+        'WAC-Allow': 'user="read append",public="read append"',
+        'Access-Control-Expose-Headers': /(^|,\s*)WAC-Allow(,|$)/
+      }
     })
 
     describeHeaderTest('read/write for the user, read for the public', {
       resource: '/user-rw-public-r',
-      headers: { 'WAC-Allow': 'user="read write append",public="read"' }
+      headers: {
+        'WAC-Allow': 'user="read write append",public="read"',
+        'Access-Control-Expose-Headers': /(^|,\s*)WAC-Allow(,|$)/
+      }
     })
 
     describeHeaderTest('read/write/append/control for the user, nothing for the public', {
       resource: '/user-rwac-public-0',
-      headers: { 'WAC-Allow': 'user="read write append control",public=""' }
+      headers: {
+        'WAC-Allow': 'user="read write append control",public=""',
+        'Access-Control-Expose-Headers': /(^|,\s*)WAC-Allow(,|$)/
+      }
     })
   })
 
@@ -44,9 +53,17 @@ describe('Header handler', () => {
 
       for (const header in headers) {
         const value = headers[header]
-        it(`has a ${header} header of ${value}`, () => {
-          expect(response.headers).to.have.property(header.toLowerCase(), value)
-        })
+        const name = header.toLowerCase()
+        if (value instanceof RegExp) {
+          it(`has a ${header} header matching ${value}`, () => {
+            expect(response.headers).to.have.property(name)
+            expect(response.headers[name]).to.match(value)
+          })
+        } else {
+          it(`has a ${header} header of ${value}`, () => {
+            expect(response.headers).to.have.property(name, value)
+          })
+        }
       }
     })
   }

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -106,7 +106,7 @@ describe('HTTP APIs', function () {
           .expect('Access-Control-Allow-Origin', 'http://example.com')
           .expect('Access-Control-Allow-Credentials', 'true')
           .expect('Access-Control-Allow-Methods', 'OPTIONS,HEAD,GET,PATCH,POST,PUT,DELETE')
-          .expect('Access-Control-Expose-Headers', 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, Content-Length, WWW-Authenticate')
+          .expect('Access-Control-Expose-Headers', 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate')
           .expect(204, done)
       })
 


### PR DESCRIPTION
Sets the proper CORS permissions on the header introduced in #550.