### PR TITLE
Fix requirement for additional verification logging in with WebID-TLS

### DIFF
--- a/lib/models/authenticator.js
+++ b/lib/models/authenticator.js
@@ -214,7 +214,7 @@ class TlsAuthenticator extends Authenticator {
 
       .then(cert => this.extractWebId(cert))
 
-      .then(webId => this.ensureLocalUser(webId))
+      .then(webId => this.loadUser(webId))
   }
 
   /**
@@ -304,36 +304,23 @@ class TlsAuthenticator extends Authenticator {
   }
 
   /**
-   * Ensures that the extracted WebID URI is hosted on this server. If it is,
-   * returns a UserAccount instance for that WebID, throws an error otherwise.
+   * Returns a user account instance for a given Web ID.
    *
    * @param webId {string}
    *
-   * @throws {Error} If the account is not hosted on this server
-   *
    * @return {UserAccount}
    */
-  ensureLocalUser (webId) {
+  loadUser (webId) {
     const serverUri = this.accountManager.host.serverUri
 
     if (domainMatches(serverUri, webId)) {
       // This is a locally hosted Web ID
-      return Promise.resolve(this.accountManager.userAccountFrom({ webId }))
+      return this.accountManager.userAccountFrom({ webId })
+    } else {
+      debug(`WebID URI ${JSON.stringify(webId)} is not a local account, using it as an external WebID`)
+
+      return this.accountManager.userAccountFrom({ webId, username: webId, externalWebId: true })
     }
-
-    debug(`WebID URI ${JSON.stringify(webId)} is not a local account, verifying authorized provider`)
-
-    return this.discoverProviderFor(webId)
-      .then(authorizedProvider => {
-        debug(`Authorized provider for ${webId} is ${authorizedProvider}`)
-
-        if (authorizedProvider === serverUri) {  // everything checks out
-          return this.accountManager.userAccountFrom({ webId, username: webId, externalWebId: true })
-        }
-
-        throw new Error(`This server is not the authorized provider for Web ID ${webId}. 
-        See https://github.com/solid/webid-oidc-spec#authorized-oidc-issuer-discovery`)
-      })
   }
 }
 


### PR DESCRIPTION
Fixes the issue of requiring the `solid:oidcIssuer` triple in the profile when logging in via WebID-TLS
with externally hosted Web IDs.