### PR TITLE
Remove debug overhead on ACL

### DIFF
--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -21,7 +21,6 @@ class ACLChecker {
   // Returns a fulfilled promise when the user can access the resource
   // in the given mode, or rejects with an HTTP error otherwise
   can (user, mode) {
-    debug(`Can ${user || 'an agent'} ${mode} ${this.resource}?`)
     // If this is an ACL, Control mode must be present for any operations
     if (this.isAcl(this.resource)) {
       mode = 'Control'
@@ -36,13 +35,10 @@ class ACLChecker {
     // Check the resource's permissions
     return this._permissionSet
       .then(acls => this.checkAccess(acls, user, mode))
-      .catch(err => {
-        debug(`Error: ${err.message}`)
+      .catch(() => {
         if (!user) {
-          debug('Authentication required')
           throw new HTTPError(401, `Access to ${this.resource} requires authorization`)
         } else {
-          debug(`${mode} access denied for ${user}`)
           throw new HTTPError(403, `Access to ${this.resource} denied for ${user}`)
         }
       })
@@ -94,17 +90,10 @@ class ACLChecker {
     return permissionSet.checkAccess(this.resource, user, mode)
       .then(hasAccess => {
         if (hasAccess) {
-          debug(`${mode} access permitted to ${user}`)
           return true
         } else {
-          debug(`${mode} access NOT permitted to ${user}`)
           throw new Error('ACL file found but no matching policy found')
         }
-      })
-      .catch(err => {
-        debug(`${mode} access denied to ${user}`)
-        debug(err)
-        throw err
       })
   }
 

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -4,6 +4,7 @@ var ACL = require('../acl-checker')
 var $rdf = require('rdflib')
 var url = require('url')
 var utils = require('../utils')
+var debug = require('../debug.js').ACL
 
 function allow (mode) {
   return function allowHandler (req, res, next) {
@@ -36,8 +37,12 @@ function allow (mode) {
       })
 
       // Ensure the user has the required permission
-      req.acl.can(req.session.userId, mode)
-             .then(() => next(), next)
+      const userId = req.session.userId
+      req.acl.can(userId, mode)
+        .then(() => next(), err => {
+          debug(`${mode} access denied to ${userId || '(none)'}`)
+          next(err)
+        })
     })
   }
 }

--- a/lib/header.js
+++ b/lib/header.js
@@ -112,6 +112,8 @@ function addPermissions (req, res, next) {
     getPermissionsFor(acl, session.userId, resource)
   ])
   .then(([publicPerms, userPerms]) => {
+    debug.ACL(`Permissions for ${session.userId || '(none)'}: ${userPerms}`)
+    debug.ACL(`Permissions for public: ${publicPerms}`)
     res.set('WAC-Allow', `user="${userPerms}",public="${publicPerms}"`)
   })
   .then(next, next)


### PR DESCRIPTION
Fixes #558, the debug output for the same action is now:

```
  solid:ACL Check if ACL exists: https://localhost:8443/profile/card.acl +6s
  solid:ACL Permissions for (none): read +28ms
  solid:ACL Permissions for public: read +0ms
  solid:get /profile/card on localhost +1ms
  solid:get HEAD only +1ms
```