### PR TITLE
Add a /public folder in new accounts

### DIFF
--- a/default-templates/new-account/public/.acl
+++ b/default-templates/new-account/public/.acl
@@ -1,0 +1,19 @@
+# ACL resource for the public folder
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# The owner has all permissions
+<#owner>
+    a acl:Authorization;
+    acl:agent <{{webId}}>;
+    acl:accessTo <./>;
+    acl:defaultForNew <./>;
+    acl:mode acl:Read, acl:Write, acl:Control.
+
+# The public has read permissions
+<#public>
+    a acl:Authorization;
+    acl:agentClass foaf:Agent;
+    acl:accessTo <./>;
+    acl:defaultForNew <./>;
+    acl:mode acl:Read.


### PR DESCRIPTION
When an account is created, there's currently no folder that is publicly readable. This pull request adds `/public` with all permissions for the owner, and (inherited) read permissions for the public.