### PR TITLE
Use data browser for containers as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ $ solid start --help
     --ssl-cert [value]      Path to the SSL certificate key in PEM format
     --multiuser             Enable multi-user mode
     --corsProxy [value]     Serve the CORS proxy on this path
-    --file-browser [value]  Url to file browser app (uses Warp by default)
     --data-browser          Enable viewing RDF resources using a default data browser application (e.g. mashlib)
     --suffix-acl [value]    Suffix for acl files (default: '.acl')
     --suffix-meta [value]   Suffix for metadata files (default: '.meta')
@@ -293,13 +292,7 @@ accidentally commit your certificates to `solid` while you're developing.
 If you started your `solid` server locally on port 8443 as in the example
 above, you would then be able to visit `https://localhost:8443` in the browser
 (ignoring the Untrusted Connection browser warnings as usual), where your
-`solid` server would redirect you to the default viewer app (see the
-`--file-browser` server config parameter), which is usually the
-[github.io/warp](https://linkeddata.github.io/warp/#/list/) file browser.
-
-Accessing most Solid apps (such as Warp) will prompt you to select your browser
-side certificate which contains a WebID from a Solid storage provider (see
-the [pre-requisites](#pre-requisites) discussion above).
+`solid` server would redirect you to the default data viewer app.
 
 #### Editing your local `/etc/hosts`
 

--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -174,19 +174,6 @@ module.exports = [
     hide: true
   },
   {
-    name: 'file-browser',
-    help: 'Type the URL of default app to use for browsing files (or use default)',
-    default: 'default',
-    filter: function (value) {
-      if (value === 'default' || value === 'warp') {
-        return 'https://linkeddata.github.io/warp/#/list/'
-      }
-      return value
-    },
-    prompt: false
-  },
-
-  {
     name: 'suppress-data-browser',
     help: 'Suppress provision of a data browser',
     flag: true,
@@ -194,7 +181,6 @@ module.exports = [
     default: false,
     hide: false
   },
-
   {
     name: 'data-browser-path',
     help: 'An HTML file which is sent to allow users to browse the data (eg using mashlib.js)',

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -75,19 +75,13 @@ function handler (req, res, next) {
       return next()
     }
 
-    // Handle fileBrowser and dataBrowser
+    // Handle dataBrowser
     if (requestedType && requestedType.includes('text/html')) {
-      if (container && ldp.fileBrowser) {
-        var address = req.protocol + '/' + req.get('host') + req.originalUrl
-        return res.redirect(303, ldp.fileBrowser + address)
-      }
-
       let mimeTypeByExt = mime.lookup(_path.basename(path))
       let isHtmlResource = mimeTypeByExt && mimeTypeByExt.includes('html')
-      let useDataBrowser = RDFs.includes(contentType) &&
-        !isHtmlResource &&  // filter out .html which IS an RDF type, but does not use data browser
-        !ldp.suppressDataBrowser &&
-        ldp.dataBrowserPath
+      let useDataBrowser = ldp.dataBrowserPath && (
+          container ||
+          RDFs.includes(contentType) && !isHtmlResource && !ldp.suppressDataBrowser)
 
       if (useDataBrowser) {
         res.set('Content-Type', 'text/html')

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -64,11 +64,6 @@ class LDP {
       }
     }
 
-    if (this.fileBrowser !== false) {
-      this.fileBrowser = argv.fileBrowser ||
-        'https://linkeddata.github.io/warp/#/list/'
-    }
-
     if (this.skin !== false) {
       this.skin = true
     }
@@ -87,7 +82,6 @@ class LDP {
     debug.settings('Allow WebID authentication: ' + !!this.webid)
     debug.settings('Live-updates: ' + !!this.live)
     debug.settings('Multi-user: ' + !!this.multiuser)
-    debug.settings('Default file browser app: ' + this.fileBrowser)
     debug.settings('Suppress default data browser app: ' + this.suppressDataBrowser)
     debug.settings('Default data browser app file path: ' + this.dataBrowserPath)
 

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -42,7 +42,6 @@ describe('Authentication API (OIDC)', () => {
     sslCert: path.join(__dirname, '../keys/cert.pem'),
     auth: 'oidc',
     dataBrowser: false,
-    fileBrowser: false,
     webid: true,
     multiuser: false,
     configPath

--- a/test/integration/capability-discovery-test.js
+++ b/test/integration/capability-discovery-test.js
@@ -19,7 +19,6 @@ describe('API', () => {
     sslCert: path.join(__dirname, '../keys/cert.pem'),
     auth: 'oidc',
     dataBrowser: false,
-    fileBrowser: false,
     webid: true,
     multiuser: false,
     configPath

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -276,11 +276,11 @@ describe('HTTP APIs', function () {
         .end(done)
     })
 
-    it('should redirect to file browser if container was requested as text/html', function (done) {
+    it('should show data browser if container was requested as text/html', function (done) {
       server.get('/sampleContainer2/')
         .set('Accept', 'text/html')
         .expect('content-type', /text\/html/)
-        .expect(303, done)
+        .expect(200, done)
     })
     it('should redirect to the right container URI if missing /', function (done) {
       server.get('/sampleContainer')


### PR DESCRIPTION
Removes Warp as well as the separate `--file-browser` option. Closes #537.