### PR TITLE
CLI modularized, express injection allowed

### DIFF
--- a/bin/lib/cli.js
+++ b/bin/lib/cli.js
@@ -1,0 +1,15 @@
+var program = require('commander')
+var packageJson = require('../../package.json')
+var loadInit = require('./init')
+var loadStart = require('./start')
+
+module.exports = function cli (server) {
+  program
+  .version(packageJson.version)
+
+  loadInit(program)
+  loadStart(program, server)
+
+  program.parse(process.argv)
+  if (program.args.length === 0) program.help()
+}

--- a/bin/lib/cli.js
+++ b/bin/lib/cli.js
@@ -1,11 +1,10 @@
-var program = require('commander')
-var packageJson = require('../../package.json')
-var loadInit = require('./init')
-var loadStart = require('./start')
+const program = require('commander')
+const packageJson = require('../../package.json')
+const loadInit = require('./init')
+const loadStart = require('./start')
 
-module.exports = function cli (server) {
-  program
-  .version(packageJson.version)
+module.exports = function startCli (server) {
+  program.version(packageJson.version)
 
   loadInit(program)
   loadStart(program, server)

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -6,7 +6,7 @@ const extend = require('extend')
 const packageJson = require('../../package.json')
 const colors = require('colors/safe')
 
-module.exports = function (program) {
+module.exports = function (program, server) {
   const start = program
     .command('start')
     .description('run the Solid server')
@@ -38,12 +38,12 @@ module.exports = function (program) {
         })
       }
 
-      bin(argv)
+      bin(argv, server)
     })
   })
 }
 
-function bin (argv) {
+function bin (argv, server) {
   if (!argv.email) {
     argv.email = {
       host: argv['emailHost'],
@@ -117,7 +117,7 @@ function bin (argv) {
   const solid = require('../../')
   let app
   try {
-    app = solid.createServer(argv)
+    app = solid.createServer(argv, server)
   } catch (e) {
     if (e.code === 'EACCES') {
       console.log(colors.red.bold('ERROR'), 'You need root privileges to start on this port')

--- a/bin/solid
+++ b/bin/solid
@@ -1,15 +1,3 @@
 #!/usr/bin/env node
-
-var program = require('commander')
-var packageJson = require('../package.json')
-var loadInit = require('./lib/init')
-var loadStart = require('./lib/start')
-
-program
-  .version(packageJson.version)
-
-loadInit(program)
-loadStart(program)
-
-program.parse(process.argv)
-if (program.args.length === 0) program.help()
+const cli = require('./lib/cli')
+cli()

--- a/bin/solid
+++ b/bin/solid
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-const cli = require('./lib/cli')
-cli()
+const startCli = require('./lib/cli')
+startCli()

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 module.exports = require('./lib/create-app')
 module.exports.createServer = require('./lib/create-server')
+module.exports.cli = require('./bin/lib/cli')

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = require('./lib/create-app')
 module.exports.createServer = require('./lib/create-server')
-module.exports.cli = require('./bin/lib/cli')
+module.exports.startCli = require('./bin/lib/cli')


### PR DESCRIPTION
As issued in #574 
This is a simple modularization of CLI so it is possible to reuse it and inject own express like this:
```js
#!/usr/bin/env node

const startCli = require('solid-server').startCli
const express = require('express')
const rdfFormatsProxy = require('http-rdf-formats-proxy')
const server = express()

server.get('/version', function (req, res) {
  res.json({ "version": require('./package.json').version })
})
server.use('/rdf-formats-proxy', rdfFormatsProxy())

startCli(server)
```
EDIT: renamed cli() to startCli()