### PR TITLE
fixed path for default templates and views

### DIFF
--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -85,7 +85,7 @@ function initConfigDir (argv) {
  * @return {string} Path to the views dir
  */
 function initDefaultViews (configPath) {
-  let defaultViewsPath = path.resolve('./default-views')
+  let defaultViewsPath = path.join(__dirname, '../default-views')
   let viewsPath = path.join(configPath, 'views')
 
   ensureDirCopyExists(defaultViewsPath, viewsPath)
@@ -106,17 +106,17 @@ function initDefaultViews (configPath) {
  */
 function initTemplateDirs (configPath) {
   let accountTemplatePath = ensureDirCopyExists(
-    './default-templates/new-account',
+    path.join(__dirname, '../default-templates/new-account'),
     path.join(configPath, 'templates', 'new-account')
   )
 
   let emailTemplatesPath = ensureDirCopyExists(
-    './default-templates/emails',
+    path.join(__dirname, '../default-templates/emails'),
     path.join(configPath, 'templates', 'emails')
   )
 
   let serverTemplatePath = ensureDirCopyExists(
-    './default-templates/server',
+    path.join(__dirname, '../default-templates/server'),
     path.join(configPath, 'templates', 'server')
   )
 


### PR DESCRIPTION
If solid-server is run from different location (ie. requiring `solid-server` as a library) first time, it cannot find default-* directories because their paths are relative. I'm getting:
```
ERROR ENOENT: no such file or directory, stat '/home/klip/projects/sendilo/default-templates/new-account'
ERROR ENOENT: no such file or directory, stat '/home/klip/projects/sendilo/default-views'
```
Fixed when relative paths changed to absolute paths with `path.join(__dirname, ...)`