### PR TITLE
Add file extension to generated paths on POST

### DIFF
--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -6,6 +6,7 @@ var path = require('path')
 var header = require('../header')
 var patch = require('./patch')
 var error = require('../http-error')
+var { extensions } = require('mime-types')
 
 function handler (req, res, next) {
   var ldp = req.app.locals.ldp
@@ -80,20 +81,19 @@ function handler (req, res, next) {
 
   function one () {
     debug('Receving one file')
-    var linkHeader = header.parseMetadataFromHeader(req.get('Link'))
-    var slug = req.get('Slug')
-    ldp.post(
-      req.hostname,
-      containerPath,
-      slug,
-      req,
-      linkHeader.isBasicContainer,
+    const { slug, link, 'content-type': contentType } = req.headers
+    const links = header.parseMetadataFromHeader(link)
+    const mimeType = contentType ? contentType.replace(/\s*;.*/, '') : ''
+    const extension = mimeType in extensions ? `.${extensions[mimeType][0]}` : ''
+
+    ldp.post(req.hostname, containerPath, req,
+      { slug, extension, container: links.isBasicContainer },
       function (err, resourcePath) {
         if (err) {
           return next(err)
         }
         debug('File stored in ' + resourcePath)
-        header.addLinks(res, linkHeader)
+        header.addLinks(res, links)
         res.set('Location', resourcePath)
         res.sendStatus(201)
         next()

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -17,6 +17,7 @@ var ldpContainer = require('./ldp-container')
 var parse = require('./utils').parse
 
 const DEFAULT_CONTENT_TYPE = 'text/turtle'
+const DEFAULT_EXTENSION = '.ttl'
 
 const RDF_MIME_TYPES = [
   'text/turtle',            // .ttl
@@ -184,7 +185,7 @@ class LDP {
     .then(result => callback(null, result), callback)
   }
 
-  post (hostname, containerPath, slug, stream, container, callback) {
+  post (host, containerPath, stream, { container, slug, extension }, callback) {
     var ldp = this
     debug.handlers('POST -- On parent: ' + containerPath)
     // prepare slug
@@ -195,8 +196,10 @@ class LDP {
         return
       }
     }
+    // No need to use the default extension, as we know its MIME type already
+    if (extension === DEFAULT_EXTENSION) extension = ''
     // TODO: possibly package this in ldp.post
-    ldp.getAvailablePath(hostname, containerPath, slug, function (resourcePath) {
+    ldp.getAvailablePath(host, containerPath, { slug, extension }).then(resourcePath => {
       debug.handlers('POST -- Will create at: ' + resourcePath)
       let originalPath = resourcePath
       if (container) {
@@ -206,7 +209,7 @@ class LDP {
           originalPath += '/'
         }
       }
-      ldp.put(hostname, resourcePath, stream, function (err) {
+      ldp.put(host, resourcePath, stream, function (err) {
         if (err) callback(err)
         callback(null, originalPath)
       })
@@ -281,15 +284,15 @@ class LDP {
     })
   }
 
-  exists (host, reqPath, callback) {
-    var options = {
-      'hostname': host,
-      'path': reqPath,
-      'baseUri': undefined,
-      'includeBody': false,
-      'possibleRDFType': undefined
+  exists (hostname, path, callback) {
+    const options = { hostname, path, includeBody: false }
+    if (callback) {
+      return this.get(options, callback)
+    } else {
+      return new Promise((resolve, reject) => {
+        this.get(options, err => err ? reject(err) : resolve(true))
+      })
     }
-    this.get(options, callback)
   }
 
   /**
@@ -478,27 +481,19 @@ class LDP {
     })
   }
 
-  getAvailablePath (host, containerURI, slug, callback) {
-    var self = this
-    slug = slug || uuid.v1()
-
-    function ensureNotExists (newPath) {
-      return new Promise(resolve => {
-        self.exists(host, newPath, function (err) {
-          // If an error occurred, the resource does not exist yet
-          if (err) {
-            resolve(newPath)
-          // Otherwise, generate a new path
-          } else {
-            const id = uuid.v1().split('-')[ 0 ] + '-'
-            newPath = path.join(containerURI, id + slug)
-            resolve(ensureNotExists(newPath))
-          }
-        })
-      })
+  getAvailablePath (host, containerURI, { slug = uuid.v1(), extension }) {
+    const filename = slug + extension
+    function ensureNotExists (self, newPath) {
+      // Verify whether the new path already exists
+      return self.exists(host, newPath).then(
+        // If it does, generate another one
+        () => ensureNotExists(self, path.join(containerURI,
+                `${uuid.v1().split('-')[0]}-${filename}`)),
+        // If not, we found an appropriate path
+        () => newPath
+      )
     }
-
-    return ensureNotExists(path.join(containerURI, slug)).then(callback)
+    return ensureNotExists(this, path.join(containerURI, filename))
   }
 }
 module.exports = LDP

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -17,7 +17,6 @@ var ldpContainer = require('./ldp-container')
 var parse = require('./utils').parse
 
 const DEFAULT_CONTENT_TYPE = 'text/turtle'
-const DEFAULT_EXTENSION = '.ttl'
 
 const RDF_MIME_TYPES = [
   'text/turtle',            // .ttl
@@ -196,8 +195,10 @@ class LDP {
         return
       }
     }
-    // No need to use the default extension, as we know its MIME type already
-    if (extension === DEFAULT_EXTENSION) extension = ''
+    // Containers should not receive an extension
+    if (container) {
+      extension = ''
+    }
     // TODO: possibly package this in ldp.post
     ldp.getAvailablePath(host, containerPath, { slug, extension }).then(resourcePath => {
       debug.handlers('POST -- Will create at: ' + resourcePath)

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -510,7 +510,7 @@ describe('HTTP APIs', function () {
       server.post('/post-tests/')
         .send(postRequest1Body)
         .set('content-type', 'text/turtle')
-        .set('slug', 'post-resource-1.ttl')
+        .set('slug', 'post-resource-1')
         .expect('location', /\/post-resource-1/)
         .expect(hasHeader('describedBy', suffixMeta))
         .expect(hasHeader('acl', suffixAcl))
@@ -521,7 +521,7 @@ describe('HTTP APIs', function () {
         server.post('')
           .send(postRequest1Body)
           .set('content-type', 'text/turtle')
-          .set('slug', 'post-test-target.ttl')
+          .set('slug', 'post-test-target')
           .expect('location', /\/post-test-target\.ttl/)
           .expect(hasHeader('describedBy', suffixMeta))
           .expect(hasHeader('acl', suffixAcl))
@@ -531,7 +531,7 @@ describe('HTTP APIs', function () {
       server.post('/hello.html/')
         .send(postRequest1Body)
         .set('content-type', 'text/turtle')
-        .set('slug', 'post-test-target2.ttl')
+        .set('slug', 'post-test-target2')
         .expect(404, done)
     })
     it('should create a new slug if there is a resource with the same name',
@@ -539,7 +539,7 @@ describe('HTTP APIs', function () {
         server.post('/post-tests/')
           .send(postRequest1Body)
           .set('content-type', 'text/turtle')
-          .set('slug', 'post-resource-1.ttl')
+          .set('slug', 'post-resource-1')
           .expect(201, done)
       })
     it('should be able to delete newly created resource', function (done) {
@@ -624,9 +624,9 @@ describe('HTTP APIs', function () {
                 .then(res => { response = res })
         )
 
-        it('is assigned an extensionless URL', () => {
+        it('is assigned an URL with the .ttl extension', () => {
           expect(response.headers).to.have.property('location')
-          expect(response.headers.location).to.match(/^\/post-tests\/[^./]+$/)
+          expect(response.headers.location).to.match(/^\/post-tests\/[^./]+\.ttl$/)
         })
       })
 
@@ -639,8 +639,8 @@ describe('HTTP APIs', function () {
                 .then(res => { response = res })
         )
 
-        it('is assigned an extensionless URL', () => {
-          expect(response.headers).to.have.property('location', '/post-tests/slug1')
+        it('is assigned an URL with the .ttl extension', () => {
+          expect(response.headers).to.have.property('location', '/post-tests/slug1.ttl')
         })
       })
 


### PR DESCRIPTION
This commit appends an extension to generated paths for POST requests,
reflecting the Content-Type of the request. This enables the server
to serve that file back with the correct content type.
For example, if a text/html request is posted, it will receive
the .html extension and will hence be served back as text/html.

Addresses the POST case of #275.