### PR TITLE
Simplify request logging

### DIFF
--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -46,18 +46,19 @@ class ACLChecker {
 
   // Gets the ACL that applies to the resource
   getNearestACL () {
+    const { resource } = this
     let isContainer = false
     // Create a cascade of reject handlers (one for each possible ACL)
     let nearestACL = Promise.reject()
     for (const acl of this.getPossibleACLs()) {
       nearestACL = nearestACL.catch(() => new Promise((resolve, reject) => {
-        debug(`Check if ACL exists: ${acl}`)
         this.fetch(acl, (err, graph) => {
           if (err || !graph || !graph.length) {
-            if (err) debug(`Error reading ${acl}: ${err}`)
             isContainer = true
             reject(err)
           } else {
+            const relative = resource.replace(acl.replace(/[^/]+$/, ''), './')
+            debug(`Using ACL ${acl} for ${relative}`)
             resolve({ acl, graph, isContainer })
           }
         })

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -98,7 +98,6 @@ function handler (req, res, next) {
 
     // If request accepts the content-type we found
     if (negotiator.mediaType([contentType])) {
-      debug('no translation necessary ' + contentType)
       res.setHeader('Content-Type', contentType)
       if (contentRange) {
         var headers = { 'Content-Range': contentRange, 'Accept-Ranges': 'bytes', 'Content-Length': chunksize }

--- a/lib/header.js
+++ b/lib/header.js
@@ -112,8 +112,8 @@ function addPermissions (req, res, next) {
     getPermissionsFor(acl, session.userId, resource)
   ])
   .then(([publicPerms, userPerms]) => {
-    debug.ACL(`Permissions for ${session.userId || '(none)'}: ${userPerms}`)
-    debug.ACL(`Permissions for public: ${publicPerms}`)
+    debug.ACL(`Permissions on ${resource} for ${session.userId || '(none)'}: ${userPerms}`)
+    debug.ACL(`Permissions on ${resource} for public: ${publicPerms}`)
     res.set('WAC-Allow', `user="${userPerms}",public="${publicPerms}"`)
   })
   .then(next, next)

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -411,11 +411,11 @@ class LDP {
         }
         stream
           .on('error', function (err) {
-            debug.handlers('GET -- Read error:' + err.message)
+            debug.handlers(`GET -- error reading ${filename}: ${err.message}`)
             return callback(error(err, "Can't create file " + err))
           })
           .on('open', function () {
-            debug.handlers('GET -- Read Start.')
+            debug.handlers(`GET -- Reading ${filename}`)
             var contentType = mime.lookup(filename) || DEFAULT_CONTENT_TYPE
             if (utils.hasSuffix(filename, ldp.turtleExtensions)) {
               contentType = 'text/turtle'


### PR DESCRIPTION
Example output when requesting `https://localhost:8443/public/abc/def/ghi/jkl`:

```
  solid:ACL Using ACL https://localhost:8443/public/.acl for ./abc/def/ghi/jkl +2s
  solid:ACL Permissions on https://localhost:8443/public/abc/def/ghi/jkl for (none): read +5ms
  solid:ACL Permissions on https://localhost:8443/public/abc/def/ghi/jkl for public: read +0ms
  solid:get /public/abc/def/ghi/jkl on localhost +0ms
  solid:handlers GET -- Reading /www/node-solid-server/data/public/abc/def/ghi/jkl +1ms
```

Closes #589.