### PR TITLE
databrowser - removed url slicing before going to subject

### DIFF
--- a/static/databrowser.html
+++ b/static/databrowser.html
@@ -17,8 +17,8 @@
         UI.authn.checkUser()
           .then(function () {
             var uri = window.location.href
-            var dataUri = window.document.title = uri.slice(0, uri.lastIndexOf('/')+1) + ''
-            var subject = UI.rdf.sym(dataUri)
+            window.document.title = uri
+            var subject = UI.rdf.namedNode(uri)
             UI.outline.GotoSubject(subject, true, undefined, true, undefined)
           })
       })


### PR DESCRIPTION
fixes #603

reverts a change of uri opened by mashlib. it seems the slicing was accidentally copied over from the mashlib's [test/index.html](https://github.com/linkeddata/mashlib/blob/master/test/index.html#L26)