### PR TITLE
Added files and instructions to build and run with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:6.11.1-onbuild
+EXPOSE 8443
+RUN cp config.json-default config.json
+RUN openssl req \
+    -new \
+    -newkey rsa:4096 \
+    -days 365 \
+    -nodes \
+    -x509 \
+    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" \
+    -keyout cert.key \
+    -out cert.pem
+CMD npm run solid start

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@
 
 ### Install
 
+You can install and run the server either using Node.js directly or using 
+[Docker](https://www.docker.com/).  This and the following sections describe the 
+first approach, for the second approach see the section [use Docker](#use-docker)
+Section below.
+
 To install, first install [Node](https://nodejs.org/en/) and then run the following
 
 ```bash
@@ -188,6 +193,27 @@ $ solid start --help
     --api-apps [value]            Path to the folder to mount on /api/apps
     -v, --verbose                 Print the logs to console
  ```
+
+## Use Docker
+
+Build with:
+
+```bash
+docker build -t node-solid-server .
+```
+
+Run with:
+```bash
+docker run -p 8443:8443 --name solid node-solid-server
+```
+
+Modify the config as follows:
+
+ - Copy the config to the current directory with: `docker cp solid:/usr/src/app/config.json .`
+ - Edit the `config.json` file
+ - Copy the file back with `docker cp config.json solid:/usr/src/app/`
+ - Restart the server with `docker restart solid`
+
 
 ## Library Usage
 

--- a/config.json-default
+++ b/config.json-default
@@ -1,0 +1,13 @@
+{
+  "root": "./data",
+  "port": "8443",
+  "serverUri": "https://localhost:8443",
+  "webid": true,
+  "mount": "/",
+  "configPath": "./config",
+  "dbPath": "./.db",
+  "sslKey": "./cert.key",
+  "sslCert": "./cert.pem",
+  "multiuser": true,
+  "corsProxy": "/proxy"
+}


### PR DESCRIPTION
With Docker one can install and node-solid-server without having to install node and npm. The resulting Docker image can easily be deployed to servers or published on dockerhub.