### PR TITLE
+ command like arg: --config-file [./config.json]

### DIFF
--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -53,6 +53,12 @@ module.exports = [
     prompt: true
   },
   {
+    name: 'config-file',
+    question: 'Path to the config file (for example: ./config.json)',
+    default: './config.json',
+    prompt: true
+  },
+  {
     name: 'db-path',
     question: 'Path to the server metadata db directory (for users/apps etc)',
     default: './.db',

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -24,8 +24,9 @@ module.exports = function (program, server) {
 
   start.action((opts) => {
     let argv = extend({}, opts, { version: program.version() })
+    let configFile = argv['configFile'] || './config.json'
 
-    fs.readFile(process.cwd() + '/config.json', (err, file) => {
+    fs.readFile(configFile, (err, file) => {
       // No file exists, not a problem
       if (err) {
         console.log(colors.cyan.bold('TIP'), 'create a config.json: `$ solid init`')


### PR DESCRIPTION
This added arg allows you to override "`./config.json`". It's kinda lame in that it doesn't actually use the default 'cause config.json is read before `require('commander').parse(process.argv)` is run so you have to include the default a la:
```
let configFile = argv['configFile'] || './config.json'
```