### PR TITLE
Update node-webid so server does not crash with no content type fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "uuid": "^3.0.0",
     "valid-url": "^1.0.9",
     "vhost": "^3.0.2",
-    "webid": "^0.3.7"
+    "webid": "^0.3.9"
   },
   "optionalDependencies": {
     "x509": "^0.3.2"


### PR DESCRIPTION
#623

Doesnt quite add the test but if fixes the issue of server crashing.