### PR TITLE
+ redirectFrom config parm

### DIFF
--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -313,7 +313,7 @@ module.exports = [
       let list = value.split(/,/).map(v => parseInt(v))
       let bad = list.find(v => { return v < 1 || v > 65535 })
       if (bad.length) {
-        return 'redirect-http-from port(s) ' + bad + ' out of length'
+        return 'redirect-http-from port(s) ' + bad + ' out of range'
       }
       return true
     }

--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -301,6 +301,22 @@ module.exports = [
     when: (answers) => {
       return answers.useApiApps
     }
+  },
+  { // copied from name: 'owner'
+    name: 'redirect-http-from',
+    help: 'HTTP port or \',\'-separated ports to redirect to the solid server port (e.g. "80,8080").',
+    prompt: false,
+    validate: function (value) {
+      if (!value.match(/^[0-9]+(,[0-9]+)*$/)) {
+        return 'direct-port(s) must be a comma-separated list of integers.'
+      }
+      let list = value.split(/,/).map(v =>  parseInt(v))
+      let bad = list.find(v => { return v < 1 || v > 65535})
+      if (bad.length) {
+        return 'redirect-http-from port(s) ' + bad + ' out of length'
+      }
+      return true
+    }
   }
 ]
 

--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -310,8 +310,8 @@ module.exports = [
       if (!value.match(/^[0-9]+(,[0-9]+)*$/)) {
         return 'direct-port(s) must be a comma-separated list of integers.'
       }
-      let list = value.split(/,/).map(v =>  parseInt(v))
-      let bad = list.find(v => { return v < 1 || v > 65535})
+      let list = value.split(/,/).map(v => parseInt(v))
+      let bad = list.find(v => { return v < 1 || v > 65535 })
       if (bad.length) {
         return 'redirect-http-from port(s) ' + bad + ' out of length'
       }

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -81,20 +81,20 @@ function createServer (argv, app) {
   }
 
   // Look for port or list of ports to redirect to argv.port
-  if ('redirectFrom' in argv) {
-    const redirectFroms = argv.redirectFrom.constructor === Array
-          ? argv.redirectFrom
-          : [argv.redirectFrom]
+  if ('redirectHTTPFrom' in argv) {
+    const redirectHTTPFroms = argv.redirectHTTPFrom.constructor === Array
+          ? argv.redirectHTTPFrom
+          : [argv.redirectHTTPFrom]
     const portStr = argv.port === 443 ? '' : ':' + argv.port
-    redirectFroms.forEach(redirectFrom => {
-      console.log('will redirect ' + redirectFrom + ' to ' + argv.port)
+    redirectHTTPFroms.forEach(redirectHTTPFrom => {
+      debug.settings('will redirect from port ' + redirectHTTPFrom + ' to port ' + argv.port)
       let redirectingServer = express()
-      redirectingServer.get('*', function(req, res) {
-        let [host, port] = req.headers.host.split(':')
-        console.log(host, '=> https://' + host + portStr + req.url)
+      redirectingServer.get('*', function (req, res) {
+        let host = req.headers.host.split(':') // ignore port
+        debug.server(host, '=> https://' + host + portStr + req.url)
         res.redirect('https://' + host + portStr + req.url)
       })
-      redirectingServer.listen(redirectFrom);
+      redirectingServer.listen(redirectHTTPFrom)
     })
   }
 

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -80,6 +80,24 @@ function createServer (argv, app) {
     server = https.createServer(credentials, app)
   }
 
+  // Look for port or list of ports to redirect to argv.port
+  if ('redirectFrom' in argv) {
+    const redirectFroms = argv.redirectFrom.constructor === Array
+          ? argv.redirectFrom
+          : [argv.redirectFrom]
+    const portStr = argv.port === 443 ? '' : ':' + argv.port
+    redirectFroms.forEach(redirectFrom => {
+      console.log('will redirect ' + redirectFrom + ' to ' + argv.port)
+      let redirectingServer = express()
+      redirectingServer.get('*', function(req, res) {
+        let [host, port] = req.headers.host.split(':')
+        console.log(host, '=> https://' + host + portStr + req.url)
+        res.redirect('https://' + host + portStr + req.url)
+      })
+      redirectingServer.listen(redirectFrom);
+    })
+  }
+
   // Setup Express app
   if (ldp.live) {
     var solidWs = SolidWs(server, ldpApp)


### PR DESCRIPTION
  `redirectFrom: 80,
`or
  `redirectFrom: [80 8088 8888]
`
```
          ISSUES: pretty logging: currently monoton:
            solid:settings Server URI: https://ericp.localhost:8443 +0ms
            ...
            solid:settings SSL Certificate path: ../self/keys/localhost2.cert +0ms
1->       will redirect 8080 to 8443
          Solid server (v4.0.1-9-g3e44601) running on https://localhost:8443/
          Press <ctrl>+c to stop
            solid:authentication Provider keys loaded from config +13ms
            ...
            solid:authentication Local RP client initialized +0ms
2->       localhost => https://localhost:8443/foo/bar
2->       localhost => https://localhost:8443/foo/bar

```

`1` appears once per entry in the array of `redirectFrom` ports.
`2` appears once per executed redirect.