### PR TITLE
Send full returnToUrl to oidc-auth-manager

### DIFF
--- a/default-views/auth/login-tls.hbs
+++ b/default-views/auth/login-tls.hbs
@@ -30,10 +30,11 @@
         return response
       })
       .then(function(response) {
-        // TODO: redirect to proper location stored in hidden field redirect_uri
-        // depends on https://github.com/solid/node-solid-server/pull/648
-        // and https://github.com/solid/oidc-auth-manager/issues/17
-        window.location.href = '/'
+        // Temporary solution to restore return URL
+        // until https://github.com/solid/oidc-auth-manager/issues/17 is resolved
+        const returnToUrl = localStorage.getItem('returnToUrl')
+        localStorage.removeItem('returnToUrl')
+        window.location.href = returnToUrl || '/'
       })
   })
 </script>

--- a/default-views/auth/select-provider.hbs
+++ b/default-views/auth/select-provider.hbs
@@ -28,5 +28,14 @@
     <button type="submit" class="btn btn-primary" id="discover">Submit</button>
   </form>
 </div>
+<script>
+  // Temporary solution to preserve return URL
+  // until https://github.com/solid/oidc-auth-manager/issues/17 is resolved
+  const locationUrl = new URL(location)
+  const returnToUrl = locationUrl.searchParams.get('returnToUrl')
+  localStorage.removeItem('returnToUrl')
+  if (returnToUrl && new URL(returnToUrl).host === locationUrl.host)
+    localStorage.setItem('returnToUrl', returnToUrl)
+</script>
 </body>
 </html>

--- a/default-views/auth/select-provider.hbs
+++ b/default-views/auth/select-provider.hbs
@@ -20,12 +20,10 @@
   {{/if}}
 </div>
 <div class="container">
-  <form method="post" action="/api/auth/select-provider">
+  <form method="post">
     <div class="form-group">
       <label for="webid">WebID or server URL:</label>
-      <input type="text" class="form-control" name="webid" id="webid"
-             value="{{serverUri}}" />
-      <input type="hidden" name="returnToUrl" id="returnToUrl" value="" />
+      <input type="text" class="form-control" name="webid" id="webid" value="{{serverUri}}" />
     </div>
     <button type="submit" class="btn btn-primary" id="discover">Submit</button>
   </form>

--- a/lib/handlers/error-pages.js
+++ b/lib/handlers/error-pages.js
@@ -163,15 +163,12 @@ function redirectToSelectProvider (req, res) {
   res.status(401)
   res.header('Content-Type', 'text/html')
 
-  let currentUrl = util.fullUrlForReq(req)
-  req.session.returnToUrl = currentUrl
-
-  let locals = req.app.locals
-  let loginUrl = locals.host.serverUri +
-    '/api/auth/select-provider?returnToUrl=' + currentUrl
+  const locals = req.app.locals
+  const currentUrl = util.fullUrlForReq(req)
+  const loginUrl = `${locals.host.serverUri}/api/auth/select-provider?returnToUrl=${encodeURIComponent(currentUrl)}`
   debug('Redirecting to Select Provider: ' + loginUrl)
 
-  let body = redirectBody(loginUrl)
+  const body = redirectBody(loginUrl)
   res.send(body)
 }
 
@@ -188,13 +185,13 @@ function redirectBody (url) {
   return `<!DOCTYPE HTML>
 <meta charset="UTF-8">
 <script>
-  window.location.href = "${url}" + window.location.hash
+  window.location.href = "${url}" + encodeURIComponent(window.location.hash)
 </script>
 <noscript>
   <meta http-equiv="refresh" content="0; url=${url}">
 </noscript>
 <title>Redirecting...</title>
-If you are not redirected automatically, 
+If you are not redirected automatically,
 follow the <a href='${url}'>link to login</a>
 `
 }


### PR DESCRIPTION
Addresses the node-solid-server part of #571.

oidc-auth-manager still loses the URL we send, so fixes on that side are needed to fully solve #571. Tracking that in https://github.com/solid/oidc-auth-manager/issues/17.