### PR TITLE
Restore WebID-TLS login in OIDC mode

### DIFF
--- a/default-views/auth/login-tls.hbs
+++ b/default-views/auth/login-tls.hbs
@@ -30,7 +30,10 @@
         return response
       })
       .then(function(response) {
-        window.location.href = response.url
+        // TODO: redirect to proper location stored in hidden field redirect_uri
+        // depends on https://github.com/solid/node-solid-server/pull/648
+        // and https://github.com/solid/oidc-auth-manager/issues/17
+        window.location.href = '/'
       })
   })
 </script>

--- a/lib/requests/login-request.js
+++ b/lib/requests/login-request.js
@@ -30,6 +30,7 @@ class LoginRequest extends AuthRequest {
     super(options)
 
     this.authenticator = options.authenticator
+    this.authMethod = options.authMethod
   }
 
   /**
@@ -44,6 +45,7 @@ class LoginRequest extends AuthRequest {
    */
   static fromParams (req, res, authMethod) {
     let options = AuthRequest.requestOptions(req, res)
+    options.authMethod = authMethod
 
     switch (authMethod) {
       case PASSWORD_AUTH:
@@ -173,10 +175,21 @@ class LoginRequest extends AuthRequest {
    * Redirects the Login request to continue on the OIDC auth workflow.
    */
   redirectPostLogin (validUser) {
+    // TODO: Make the kludge below unnecessary (e.g., by separating OIDC and TLS auth).
+    // If we have arrived here in the WebID-TLS case,
+    // this means the client has done an AJAX POST request to /login/tls.
+    // If the WebID is external, and we send out a redirect to that external URL,
+    // there is a risk that this external URL returns a non-2xx response.
+    // This in turn makes the AJAX call on the client fail,
+    // and its success code is not executed because of that failure.
+    // To prevent this, we just reply a 204 for external WebIDs.
+    if (this.authMethod === TLS_AUTH && validUser.externalWebId) {
+      debug('Login successful with WebID-TLS')
+      return this.response.header('User', validUser.webId).status(204).send()
+    }
+
     let uri = this.postLoginUrl(validUser)
-
     debug('Login successful, redirecting to ', uri)
-
     this.response.redirect(uri)
   }
 


### PR DESCRIPTION
This is a kludge to make WebID-TLS login work again when the server is running in OIDC mode. The problem I observed is as follows:

- When I would click the "Log in with WebID-TLS" button, the browser would send an AJAX `POST` request to `/login/tls`.
- That `POST` request would trigger re-negotiation on the server and ask for a client certificate.
- The server would extract my WebID from my client certificate (which is `https://ruben.verborgh.org/profile/#me`).
- The server would:
   1. incorrectly assume that I want to be directed to my own pod instead of the redirect URI (see #648);
   2. incorrectly assume that my home pod is `https://ruben.verborgh.org/`.
- Hence, the server would send a 302 response redirecting to `https://ruben.verborgh.org/`.
- Therefore, the browser (still executing the AJAX request) would redirect to `https://ruben.verborgh.org/` (without letting the AJAX script know), but that would fail because the AJAX request uses `credentials: 'include'`, which doesn't work there (nor should it).
- Since the redirected request would fail, the whole AJAX call would, and the success callback would never get executed.

As you can see from the above accumulation, the root cause of the problem is that the whole login flow is messy and, in my opinion, reeds a deeper rewriting.

For a more immediate effect, I wrote a kludge that fixes the symptoms as follows:
- Return a 204 in case of an external WebID rather than a redirect, which causes the AJAX request to succeed.

The redirect is still the wrong one; we depend on #648 to address that.