### PR TITLE
Prefer protocol configured in server URI

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -99,7 +99,13 @@ function filenameToBaseUri (filename, uri, base) {
 }
 
 function getBaseUri (req) {
-  return req.protocol + '://' + req.get('host')
+  // Obtain the protocol from the configured server URI
+  // (in case the server is running behind a reverse proxy)
+  const locals = req.app.locals
+  const serverUri = locals.host.serverUri
+  const protocol = serverUri.replace(/:.*/, '')
+
+  return `${protocol || req.protocol}://${req.get('host')}`
 }
 
 /**


### PR DESCRIPTION
The server URI's protocol would be determined based on the protocol of the request only, which could be different if Solid is behind a reverse proxy.