### PR TITLE
Align WebSocket URI with base URI

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -34,7 +34,7 @@ function handler (req, res, next) {
 
   // Set live updates
   if (ldp.live) {
-    res.header('Updates-Via', req.protocol.replace(/^http/, 'ws') + '://' + req.get('host'))
+    res.header('Updates-Via', utils.getBaseUri(req).replace(/^http/, 'ws'))
   }
 
   debug(req.originalUrl + ' on ' + req.hostname)


### PR DESCRIPTION
This makes them have the same protocol, which can be different because of #651.
I have tested both fixes in conjunction.