### PR TITLE
Use block level scope instead of function level scope

### DIFF
--- a/lib/api/authn/webid-tls.js
+++ b/lib/api/authn/webid-tls.js
@@ -1,6 +1,6 @@
-var webid = require('webid/tls')
-var debug = require('../../debug').authentication
-var x509 // optional dependency, load lazily
+const webid = require('webid/tls')
+const debug = require('../../debug').authentication
+let x509 // optional dependency, load lazily
 
 const CERTIFICATE_MATCHER = /^-----BEGIN CERTIFICATE-----\n(?:[A-Za-z0-9+/=]+\n)+-----END CERTIFICATE-----$/m
 

--- a/lib/capability-discovery.js
+++ b/lib/capability-discovery.js
@@ -29,7 +29,7 @@ module.exports = capabilityDiscovery
  * @return {Router} Express router
  */
 function capabilityDiscovery () {
-  var router = express.Router('/')
+  const router = express.Router('/')
 
   // Advertise the server capability discover endpoint
   router.get('/.well-known/solid', serviceCapabilityDocument(serviceConfigDefaults))

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -1,20 +1,20 @@
 module.exports = createServer
 
-var express = require('express')
-var fs = require('fs')
-var https = require('https')
-var http = require('http')
-var SolidWs = require('solid-ws')
-var debug = require('./debug')
-var createApp = require('./create-app')
+const express = require('express')
+const fs = require('fs')
+const https = require('https')
+const http = require('http')
+const SolidWs = require('solid-ws')
+const debug = require('./debug')
+const createApp = require('./create-app')
 const globalTunnel = require('global-tunnel-ng')
 
 function createServer (argv, app) {
   argv = argv || {}
   app = app || express()
-  var ldpApp = createApp(argv)
-  var ldp = ldpApp.locals.ldp || {}
-  var mount = argv.mount || '/'
+  const ldpApp = createApp(argv)
+  const ldp = ldpApp.locals.ldp || {}
+  let mount = argv.mount || '/'
   // Removing ending '/'
   if (mount.length > 1 &&
     mount[mount.length - 1] === '/') {
@@ -33,8 +33,8 @@ function createServer (argv, app) {
     globalTunnel.initialize(argv.httpProxy)
   }
 
-  var server
-  var needsTLS = argv.sslKey || argv.sslCert ||
+  let server
+  const needsTLS = argv.sslKey || argv.sslCert ||
                  (ldp.webid || ldp.multiuser) && !argv.certificateHeader
   if (!needsTLS) {
     server = http.createServer(app)
@@ -54,21 +54,21 @@ function createServer (argv, app) {
       throw new Error('Missing path for SSL cert')
     }
 
-    var key
+    let key
     try {
       key = fs.readFileSync(argv.sslKey)
     } catch (e) {
       throw new Error('Can\'t find SSL key in ' + argv.sslKey)
     }
 
-    var cert
+    let cert
     try {
       cert = fs.readFileSync(argv.sslCert)
     } catch (e) {
       throw new Error('Can\'t find SSL cert in ' + argv.sslCert)
     }
 
-    var credentials = Object.assign({
+    const credentials = Object.assign({
       key: key,
       cert: cert
     }, argv)
@@ -100,7 +100,7 @@ function createServer (argv, app) {
 
   // Setup Express app
   if (ldp.live) {
-    var solidWs = SolidWs(server, ldpApp)
+    const solidWs = SolidWs(server, ldpApp)
     ldpApp.locals.ldp.live = solidWs.publish.bind(solidWs)
   }
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,4 +1,4 @@
-var debug = require('debug')
+const debug = require('debug')
 
 exports.handlers = debug('solid:handlers')
 exports.errors = debug('solid:errors')

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -1,14 +1,14 @@
 module.exports = allow
 
-var ACL = require('../acl-checker')
-var $rdf = require('rdflib')
-var utils = require('../utils')
-var debug = require('../debug.js').ACL
-var LegacyResourceMapper = require('../legacy-resource-mapper')
+const ACL = require('../acl-checker')
+const $rdf = require('rdflib')
+const utils = require('../utils')
+const debug = require('../debug.js').ACL
+const LegacyResourceMapper = require('../legacy-resource-mapper')
 
 function allow (mode) {
   return function allowHandler (req, res, next) {
-    var ldp = req.app.locals.ldp || {}
+    const ldp = req.app.locals.ldp || {}
     if (!ldp.webid) {
       return next()
     }
@@ -22,7 +22,7 @@ function allow (mode) {
     })
 
     // Determine the actual path of the request
-    var reqPath = res && res.locals && res.locals.path
+    let reqPath = res && res.locals && res.locals.path
       ? res.locals.path
       : req.path
 

--- a/lib/handlers/delete.js
+++ b/lib/handlers/delete.js
@@ -1,11 +1,11 @@
 module.exports = handler
 
-var debug = require('../debug').handlers
+const debug = require('../debug').handlers
 
 function handler (req, res, next) {
   debug('DELETE -- Request on' + req.originalUrl)
 
-  var ldp = req.app.locals.ldp
+  const ldp = req.app.locals.ldp
   ldp.delete(req.hostname, req.path, function (err) {
     if (err) {
       debug('DELETE -- Failed to delete: ' + err)

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -1,32 +1,32 @@
 module.exports = handler
 
-var fs = require('fs')
-var glob = require('glob')
-var _path = require('path')
-var $rdf = require('rdflib')
-var S = require('string')
-var Negotiator = require('negotiator')
+const fs = require('fs')
+const glob = require('glob')
+const _path = require('path')
+const $rdf = require('rdflib')
+const S = require('string')
+const Negotiator = require('negotiator')
 const url = require('url')
 const mime = require('mime-types')
 
-var debug = require('debug')('solid:get')
-var debugGlob = require('debug')('solid:glob')
-var allow = require('./allow')
+const debug = require('debug')('solid:get')
+const debugGlob = require('debug')('solid:glob')
+const allow = require('./allow')
 
-var utils = require('../utils.js')
-var translate = require('../utils.js').translate
-var error = require('../http-error')
+const utils = require('../utils.js')
+const translate = require('../utils.js').translate
+const error = require('../http-error')
 
 const RDFs = require('../ldp').RDF_MIME_TYPES
 
 function handler (req, res, next) {
-  var ldp = req.app.locals.ldp
-  var includeBody = req.method === 'GET'
-  var negotiator = new Negotiator(req)
-  var baseUri = utils.getFullUri(req)
-  var path = res.locals.path || req.path
-  var requestedType = negotiator.mediaType()
-  var possibleRDFType = negotiator.mediaType(RDFs)
+  const ldp = req.app.locals.ldp
+  const includeBody = req.method === 'GET'
+  const negotiator = new Negotiator(req)
+  const baseUri = utils.getFullUri(req)
+  const path = res.locals.path || req.path
+  const requestedType = negotiator.mediaType()
+  let possibleRDFType = negotiator.mediaType(RDFs)
   // Fallback to text/turtle if content type is unknown
   possibleRDFType = (!possibleRDFType) ? 'text/turtle' : possibleRDFType
 
@@ -39,7 +39,7 @@ function handler (req, res, next) {
 
   debug(req.originalUrl + ' on ' + req.hostname)
 
-  var options = {
+  const options = {
     'hostname': req.hostname,
     'path': path,
     'baseUri': baseUri,
@@ -60,12 +60,18 @@ function handler (req, res, next) {
       return next(err)
     }
 
+    let stream
+    let contentType
+    let container
+    let contentRange
+    let chunksize
+
     if (ret) {
-      var stream = ret.stream
-      var contentType = ret.contentType
-      var container = ret.container
-      var contentRange = ret.contentRange
-      var chunksize = ret.chunksize
+      stream = ret.stream
+      contentType = ret.contentType
+      container = ret.container
+      contentRange = ret.contentRange
+      chunksize = ret.chunksize
     }
 
     // Till here it must exist
@@ -85,8 +91,8 @@ function handler (req, res, next) {
 
       if (useDataBrowser) {
         res.set('Content-Type', 'text/html')
-        var defaultDataBrowser = _path.join(__dirname, '../../static/databrowser.html')
-        var dataBrowserPath = ldp.dataBrowserPath === 'default' ? defaultDataBrowser : ldp.dataBrowserPath
+        const defaultDataBrowser = _path.join(__dirname, '../../static/databrowser.html')
+        const dataBrowserPath = ldp.dataBrowserPath === 'default' ? defaultDataBrowser : ldp.dataBrowserPath
         debug('   sending data browser file: ' + dataBrowserPath)
         res.sendFile(dataBrowserPath)
         return
@@ -100,7 +106,7 @@ function handler (req, res, next) {
     if (negotiator.mediaType([contentType])) {
       res.setHeader('Content-Type', contentType)
       if (contentRange) {
-        var headers = { 'Content-Range': contentRange, 'Accept-Ranges': 'bytes', 'Content-Length': chunksize }
+        const headers = { 'Content-Range': contentRange, 'Accept-Ranges': 'bytes', 'Content-Length': chunksize }
         res.writeHead(206, headers)
         return stream.pipe(res)
       } else {
@@ -129,13 +135,13 @@ function handler (req, res, next) {
 }
 
 function globHandler (req, res, next) {
-  var ldp = req.app.locals.ldp
-  var root = !ldp.multiuser ? ldp.root : ldp.root + req.hostname + '/'
-  var filename = utils.uriToFilename(req.path, root)
-  var uri = utils.getFullUri(req)
+  const ldp = req.app.locals.ldp
+  const root = !ldp.multiuser ? ldp.root : ldp.root + req.hostname + '/'
+  const filename = utils.uriToFilename(req.path, root)
+  const uri = utils.getFullUri(req)
   const requestUri = url.resolve(uri, req.path)
 
-  var globOptions = {
+  const globOptions = {
     noext: true,
     nobrace: true,
     nodir: true
@@ -148,13 +154,13 @@ function globHandler (req, res, next) {
     }
 
     // Matches found
-    var globGraph = $rdf.graph()
+    const globGraph = $rdf.graph()
 
     let reqOrigin = utils.getBaseUri(req)
 
     debugGlob('found matches ' + matches)
     Promise.all(matches.map(match => new Promise((resolve, reject) => {
-      var baseUri = utils.filenameToBaseUri(match, reqOrigin, root)
+      const baseUri = utils.filenameToBaseUri(match, reqOrigin, root)
       fs.readFile(match, {encoding: 'utf8'}, function (err, fileData) {
         if (err) {
           debugGlob('error ' + err)
@@ -174,7 +180,7 @@ function globHandler (req, res, next) {
       })
     })))
     .then(() => {
-      var data = $rdf.serialize(undefined, globGraph, requestUri, 'text/turtle')
+      const data = $rdf.serialize(undefined, globGraph, requestUri, 'text/turtle')
       // TODO this should be added as a middleware in the routes
       res.setHeader('Content-Type', 'text/turtle')
       debugGlob('returning turtle')
@@ -186,14 +192,14 @@ function globHandler (req, res, next) {
 }
 
 function aclAllow (match, req, res, callback) {
-  var ldp = req.app.locals.ldp
+  const ldp = req.app.locals.ldp
 
   if (!ldp.webid) {
     return callback(true)
   }
 
-  var root = ldp.multiuser ? ldp.root + req.hostname + '/' : ldp.root
-  var relativePath = '/' + _path.relative(root, match)
+  const root = ldp.multiuser ? ldp.root + req.hostname + '/' : ldp.root
+  const relativePath = '/' + _path.relative(root, match)
   res.locals.path = relativePath
   allow('Read', req, res, function (err) {
     callback(err)

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -1,16 +1,16 @@
 module.exports = handler
 
-var path = require('path')
-var debug = require('debug')('solid:index')
-var utils = require('../utils')
-var Negotiator = require('negotiator')
+const path = require('path')
+const debug = require('debug')('solid:index')
+const utils = require('../utils')
+const Negotiator = require('negotiator')
 
 function handler (req, res, next) {
-  var indexFile = 'index.html'
-  var ldp = req.app.locals.ldp
-  var negotiator = new Negotiator(req)
-  var requestedType = negotiator.mediaType()
-  var filename = utils.reqToPath(req)
+  const indexFile = 'index.html'
+  const ldp = req.app.locals.ldp
+  const negotiator = new Negotiator(req)
+  const requestedType = negotiator.mediaType()
+  const filename = utils.reqToPath(req)
 
   ldp.stat(filename, function (err, stats) {
     if (err) return next()

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -1,16 +1,16 @@
 module.exports = handler
 
-var Busboy = require('busboy')
-var debug = require('debug')('solid:post')
-var path = require('path')
-var header = require('../header')
-var patch = require('./patch')
-var error = require('../http-error')
-var { extensions } = require('mime-types')
+const Busboy = require('busboy')
+const debug = require('debug')('solid:post')
+const path = require('path')
+const header = require('../header')
+const patch = require('./patch')
+const error = require('../http-error')
+const { extensions } = require('mime-types')
 
 function handler (req, res, next) {
-  var ldp = req.app.locals.ldp
-  var contentType = req.get('content-type')
+  const ldp = req.app.locals.ldp
+  const contentType = req.get('content-type')
   debug('content-type is ', contentType)
   // Handle SPARQL(-update?) query
   if (contentType === 'application/sparql' ||
@@ -20,7 +20,7 @@ function handler (req, res, next) {
   }
 
   // Handle container path
-  var containerPath = req.path
+  let containerPath = req.path
   if (containerPath[containerPath.length - 1] !== '/') {
     containerPath += '/'
   }
@@ -31,8 +31,9 @@ function handler (req, res, next) {
       return next(error(err, 'Container not valid'))
     }
 
+    let stats
     if (ret) {
-      var stats = ret.stream
+      stats = ret.stream
     }
 
     // Check if container is a directory
@@ -52,7 +53,7 @@ function handler (req, res, next) {
   function multi () {
     debug('receving multiple files')
 
-    var busboy = new Busboy({ headers: req.headers })
+    const busboy = new Busboy({ headers: req.headers })
     busboy.on('file', function (fieldname, file, filename, encoding, mimetype) {
       debug('One file received via multipart: ' + filename)
       ldp.put(

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -1,9 +1,9 @@
 module.exports = handler
 
-var debug = require('debug')('solid:put')
+const debug = require('debug')('solid:put')
 
 function handler (req, res, next) {
-  var ldp = req.app.locals.ldp
+  const ldp = req.app.locals.ldp
   debug(req.originalUrl)
   res.header('MS-Author-Via', 'SPARQL')
 
@@ -20,4 +20,3 @@ function handler (req, res, next) {
     return next()
   })
 }
-

--- a/lib/header.js
+++ b/lib/header.js
@@ -4,19 +4,19 @@ module.exports.parseMetadataFromHeader = parseMetadataFromHeader
 module.exports.linksHandler = linksHandler
 module.exports.addPermissions = addPermissions
 
-var li = require('li')
-var path = require('path')
-var S = require('string')
-var metadata = require('./metadata.js')
-var debug = require('./debug.js')
-var utils = require('./utils.js')
-var error = require('./http-error')
+const li = require('li')
+const path = require('path')
+const S = require('string')
+const metadata = require('./metadata.js')
+const debug = require('./debug.js')
+const utils = require('./utils.js')
+const error = require('./http-error')
 
 const MODES = ['Read', 'Write', 'Append', 'Control']
 const PERMISSIONS = MODES.map(m => m.toLowerCase())
 
 function addLink (res, value, rel) {
-  var oldLink = res.get('Link')
+  const oldLink = res.get('Link')
   if (oldLink === undefined) {
     res.set('Link', '<' + value + '>; rel="' + rel + '"')
   } else {
@@ -43,9 +43,9 @@ function addLinks (res, fileMetadata) {
 }
 
 function linksHandler (req, res, next) {
-  var ldp = req.app.locals.ldp
-  var root = !ldp.multiuser ? ldp.root : ldp.root + req.hostname + '/'
-  var filename = utils.uriToFilename(req.url, root)
+  const ldp = req.app.locals.ldp
+  const root = !ldp.multiuser ? ldp.root : ldp.root + req.hostname + '/'
+  let filename = utils.uriToFilename(req.url, root)
 
   filename = path.join(filename, req.path)
   if (path.extname(filename) === ldp.suffixMeta) {
@@ -53,7 +53,7 @@ function linksHandler (req, res, next) {
 
     return next(error(404, 'Trying to access metadata file as regular file'))
   }
-  var fileMetadata = new metadata.Metadata()
+  let fileMetadata = new metadata.Metadata()
   if (S(filename).endsWith('/')) {
     fileMetadata.isContainer = true
     fileMetadata.isBasicContainer = true
@@ -73,15 +73,15 @@ function linksHandler (req, res, next) {
 }
 
 function parseMetadataFromHeader (linkHeader) {
-  var fileMetadata = new metadata.Metadata()
+  let fileMetadata = new metadata.Metadata()
   if (linkHeader === undefined) {
     return fileMetadata
   }
-  var links = linkHeader.split(',')
-  for (var linkIndex in links) {
-    var link = links[linkIndex]
-    var parsedLinks = li.parse(link)
-    for (var rel in parsedLinks) {
+  const links = linkHeader.split(',')
+  for (let linkIndex in links) {
+    const link = links[linkIndex]
+    const parsedLinks = li.parse(link)
+    for (let rel in parsedLinks) {
       if (rel === 'type') {
         if (parsedLinks[rel] === 'http://www.w3.org/ns/ldp#Resource') {
           fileMetadata.isResource = true

--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -14,10 +14,10 @@ function HTTPError (status, message) {
     this.message = message || 'Error occurred'
     this.status = status
   } else {
-    var err = status
-    var _status
-    var _code
-    var _message
+    const err = status
+    let _status
+    let _code
+    let _message
     if (err && err.status) {
       _status = err.status
     }

--- a/lib/ldp-container.js
+++ b/lib/ldp-container.js
@@ -62,7 +62,7 @@ function addFile (ldp, resourceGraph, containerUri, reqUri, uri, container, file
     // Set up a metaFile path
     // Earlier code used a .ttl file as its own meta file, which
     // caused massive data files to parsed as part of deirectory listings just looking for type triples
-    var metaFile = container + file + ldp.suffixMeta
+    const metaFile = container + file + ldp.suffixMeta
 
     getMetadataGraph(ldp, metaFile, memberUri, function (err, metadataGraph) {
       if (err) {
@@ -166,7 +166,7 @@ function getMetadataGraph (ldp, metaFile, fileBaseUri, callback) {
           return callback(err)
         }
 
-        var metadataGraph = $rdf.graph()
+        const metadataGraph = $rdf.graph()
         try {
           $rdf.parse(
             rawMetadata,

--- a/lib/ldp-copy.js
+++ b/lib/ldp-copy.js
@@ -33,7 +33,7 @@ function copy (copyToPath, copyFromUri, callback) {
         new Error('Failed to create the path to the destination resource: ' +
           err))
     }
-    var destinationStream = fs.createWriteStream(copyToPath)
+    const destinationStream = fs.createWriteStream(copyToPath)
       .on('error', function (err) {
         cleanupFileStream(this)
         return callback(new Error('Error writing data: ' + err))

--- a/lib/ldp-middleware.js
+++ b/lib/ldp-middleware.js
@@ -1,18 +1,18 @@
 module.exports = LdpMiddleware
 
-var express = require('express')
-var header = require('./header')
-var allow = require('./handlers/allow')
-var get = require('./handlers/get')
-var post = require('./handlers/post')
-var put = require('./handlers/put')
-var del = require('./handlers/delete')
-var patch = require('./handlers/patch')
-var index = require('./handlers/index')
-var copy = require('./handlers/copy')
+const express = require('express')
+const header = require('./header')
+const allow = require('./handlers/allow')
+const get = require('./handlers/get')
+const post = require('./handlers/post')
+const put = require('./handlers/put')
+const del = require('./handlers/delete')
+const patch = require('./handlers/patch')
+const index = require('./handlers/index')
+const copy = require('./handlers/copy')
 
 function LdpMiddleware (corsSettings) {
-  var router = express.Router('/')
+  const router = express.Router('/')
 
   // Add Link headers
   router.use(header.linksHandler)

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -1,20 +1,19 @@
-var mime = require('mime-types')
-var path = require('path')
+const mime = require('mime-types')
+const path = require('path')
 const url = require('url')
-var fs = require('fs')
-var $rdf = require('rdflib')
-// var url = require('url')
-var mkdirp = require('fs-extra').mkdirp
-var uuid = require('uuid')
-var debug = require('./debug')
-var utils = require('./utils')
-var error = require('./http-error')
-var stringToStream = require('./utils').stringToStream
-var serialize = require('./utils').serialize
-var extend = require('extend')
-var rimraf = require('rimraf')
-var ldpContainer = require('./ldp-container')
-var parse = require('./utils').parse
+const fs = require('fs')
+const $rdf = require('rdflib')
+const mkdirp = require('fs-extra').mkdirp
+const uuid = require('uuid')
+const debug = require('./debug')
+const utils = require('./utils')
+const error = require('./http-error')
+const stringToStream = require('./utils').stringToStream
+const serialize = require('./utils').serialize
+const extend = require('extend')
+const rimraf = require('rimraf')
+const ldpContainer = require('./ldp-container')
+const parse = require('./utils').parse
 
 const DEFAULT_CONTENT_TYPE = 'text/turtle'
 
@@ -118,7 +117,7 @@ class LDP {
   }
 
   readContainerMeta (directory, callback) {
-    var ldp = this
+    const ldp = this
 
     if (directory[ directory.length - 1 ] !== '/') {
       directory += '/'
@@ -134,12 +133,12 @@ class LDP {
   }
 
   listContainer (filename, reqUri, uri, containerData, contentType, callback) {
-    var ldp = this
+    const ldp = this
     // var host = url.parse(uri).hostname
     // var root = !ldp.multiuser ? ldp.root : ldp.root + host + '/'
 
     // var baseUri = utils.filenameToBaseUri(filename, uri, root)
-    var resourceGraph = $rdf.graph()
+    const resourceGraph = $rdf.graph()
 
     try {
       $rdf.parse(containerData, resourceGraph, reqUri, 'text/turtle')
@@ -185,7 +184,7 @@ class LDP {
   }
 
   post (host, containerPath, stream, { container, slug, extension }, callback) {
-    var ldp = this
+    const ldp = this
     debug.handlers('POST -- On parent: ' + containerPath)
     // prepare slug
     if (slug) {
@@ -256,9 +255,9 @@ class LDP {
   }
 
   put (host, resourcePath, stream, callback) {
-    var ldp = this
-    var root = !ldp.multiuser ? ldp.root : ldp.root + host + '/'
-    var filePath = utils.uriToFilename(resourcePath, root, host)
+    const ldp = this
+    const root = !ldp.multiuser ? ldp.root : ldp.root + host + '/'
+    const filePath = utils.uriToFilename(resourcePath, root, host)
 
     // PUT requests not supported on containers. Use POST instead
     if (filePath.endsWith('/')) {
@@ -266,7 +265,7 @@ class LDP {
         'PUT not supported on containers, use POST instead'))
     }
     // First, create the enclosing directory, if necessary
-    var dirName = path.dirname(filePath)
+    const dirName = path.dirname(filePath)
     mkdirp(dirName, (err) => {
       if (err) {
         debug.handlers('PUT -- Error creating directory: ' + err)
@@ -274,7 +273,7 @@ class LDP {
           'Failed to create the path to the new resource'))
       }
       // Directory created, now write the file
-      var file = stream.pipe(fs.createWriteStream(filePath))
+      const file = stream.pipe(fs.createWriteStream(filePath))
       file.on('error', function () {
         callback(error(500, 'Error writing data'))
       })
@@ -315,9 +314,9 @@ class LDP {
    * @return {Promise<Graph>}
    */
   getGraph (uri, contentType = DEFAULT_CONTENT_TYPE) {
-    let parsedUri = url.parse(uri)
-    let path = parsedUri.pathname
-    let hostname = parsedUri.hostname
+    const parsedUri = url.parse(uri)
+    const path = parsedUri.pathname
+    const hostname = parsedUri.hostname
 
     return new Promise((resolve, reject) => {
       this.graph(hostname, path, uri, contentType, (error, graph) => {
@@ -329,7 +328,7 @@ class LDP {
   }
 
   graph (host, reqPath, baseUri, contentType, callback) {
-    var ldp = this
+    const ldp = this
 
     // overloading
     if (typeof contentType === 'function') {
@@ -342,8 +341,8 @@ class LDP {
       baseUri = undefined
     }
 
-    var root = ldp.multiuser ? ldp.root + host + '/' : ldp.root
-    var filename = utils.uriToFilename(reqPath, root)
+    const root = ldp.multiuser ? ldp.root + host + '/' : ldp.root
+    const filename = utils.uriToFilename(reqPath, root)
 
     ldp.readFile(filename, (err, body) => {
       if (err) return callback(err)
@@ -352,17 +351,23 @@ class LDP {
   }
 
   get (options, callback) {
+    let host
+    let reqPath
+    let baseUri
+    let includeBody
+    let contentType
+    let range
     if (options) {
-      var host = options.hostname
-      var reqPath = options.path
-      var baseUri = options.baseUri
-      var includeBody = options.includeBody
-      var contentType = options.possibleRDFType
-      var range = options.range
+      host = options.hostname
+      reqPath = options.path
+      baseUri = options.baseUri
+      includeBody = options.includeBody
+      contentType = options.possibleRDFType
+      range = options.range
     }
-    var ldp = this
-    var root = !ldp.multiuser ? ldp.root : ldp.root + host + '/'
-    var filename = utils.uriToFilename(reqPath, root)
+    const ldp = this
+    const root = !ldp.multiuser ? ldp.root : ldp.root + host + '/'
+    const filename = utils.uriToFilename(reqPath, root)
 
     ldp.stat(filename, function (err, stats) {
       // File does not exist
@@ -381,30 +386,32 @@ class LDP {
           if (err) {
             metaFile = ''
           }
-          let absContainerUri = baseUri + reqPath
+          const absContainerUri = baseUri + reqPath
           ldp.listContainer(filename, absContainerUri, baseUri, metaFile, contentType,
             function (err, data) {
               if (err) {
                 debug.handlers('GET container -- Read error:' + err.message)
                 return callback(err)
               }
-              var stream = stringToStream(data)
+              const stream = stringToStream(data)
               // TODO 'text/turtle' is fixed, should be contentType instead
               // This forces one more translation turtle -> desired
               return callback(null, {'stream': stream, 'contentType': 'text/turtle', 'container': true})
             })
         })
       } else {
-        var stream
+        let stream
+        let chunksize
+        let contentRange
         if (range) {
-          var total = fs.statSync(filename).size
-          var parts = range.replace(/bytes=/, '').split('-')
-          var partialstart = parts[0]
-          var partialend = parts[1]
-          var start = parseInt(partialstart, 10)
-          var end = partialend ? parseInt(partialend, 10) : total - 1
-          var chunksize = (end - start) + 1
-          var contentRange = 'bytes ' + start + '-' + end + '/' + total
+          const total = fs.statSync(filename).size
+          const parts = range.replace(/bytes=/, '').split('-')
+          const partialstart = parts[0]
+          const partialend = parts[1]
+          const start = parseInt(partialstart, 10)
+          const end = partialend ? parseInt(partialend, 10) : total - 1
+          chunksize = (end - start) + 1
+          contentRange = 'bytes ' + start + '-' + end + '/' + total
           stream = ldp.createReadStream(filename, start, end)
         } else {
           stream = ldp.createReadStream(filename)
@@ -416,7 +423,7 @@ class LDP {
           })
           .on('open', function () {
             debug.handlers(`GET -- Reading ${filename}`)
-            var contentType = mime.lookup(filename) || DEFAULT_CONTENT_TYPE
+            let contentType = mime.lookup(filename) || DEFAULT_CONTENT_TYPE
             if (utils.hasSuffix(filename, ldp.turtleExtensions)) {
               contentType = 'text/turtle'
             }
@@ -427,9 +434,9 @@ class LDP {
   }
 
   delete (host, resourcePath, callback) {
-    var ldp = this
-    var root = !ldp.multiuser ? ldp.root : ldp.root + host + '/'
-    var filename = utils.uriToFilename(resourcePath, root)
+    const ldp = this
+    const root = !ldp.multiuser ? ldp.root : ldp.root + host + '/'
+    const filename = utils.uriToFilename(resourcePath, root)
     ldp.stat(filename, function (err, stats) {
       if (err) {
         return callback(error(404, "Can't find " + err))
@@ -444,12 +451,12 @@ class LDP {
   }
 
   deleteContainer (directory, callback) {
-    var self = this
+    const self = this
     if (directory[ directory.length - 1 ] !== '/') {
       directory += '/'
     }
 
-    var countValid = 0
+    let countValid = 0
     fs.readdir(directory, function (err, list) {
       if (err) return callback(error(404, 'The container does not exist'))
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,11 +15,11 @@ module.exports.debrack = debrack
 module.exports.stripLineEndings = stripLineEndings
 module.exports.fullUrlForReq = fullUrlForReq
 
-var fs = require('fs')
-var path = require('path')
-var S = require('string')
-var $rdf = require('rdflib')
-var from = require('from2')
+const fs = require('fs')
+const path = require('path')
+const S = require('string')
+const $rdf = require('rdflib')
+const from = require('from2')
 const url = require('url')
 
 /**
@@ -71,13 +71,13 @@ function debrack (s) {
 }
 
 function uriToFilename (uri, base) {
-  var decoded = uri.split('/').map(decodeURIComponent).join('/')
-  var filename = path.join(base, decoded)
+  const decoded = uri.split('/').map(decodeURIComponent).join('/')
+  let filename = path.join(base, decoded)
   // Make sure filename ends with '/'  if filename exists and is a directory.
   // TODO this sync operation can be avoided and can be left
   // to do, to other components, see `ldp.get`
   try {
-    var fileStats = fs.statSync(filename)
+    const fileStats = fs.statSync(filename)
     if (fileStats.isDirectory() && !filename.endsWith('/')) {
       filename += '/'
     } else if (fileStats.isFile() && filename.endsWith('/')) {
@@ -88,13 +88,13 @@ function uriToFilename (uri, base) {
 }
 
 function uriToRelativeFilename (uri, base) {
-  var filename = uriToFilename(uri, base)
-  var relative = path.relative(base, filename)
+  const filename = uriToFilename(uri, base)
+  const relative = path.relative(base, filename)
   return relative
 }
 
 function filenameToBaseUri (filename, uri, base) {
-  var uriPath = S(filename).strip(base).toString()
+  const uriPath = S(filename).strip(base).toString()
   return uri + '/' + uriPath
 }
 
@@ -127,7 +127,7 @@ function getFullUri (req) {
 }
 
 function pathBasename (fullpath) {
-  var bname = ''
+  let bname = ''
   if (fullpath) {
     bname = (fullpath.lastIndexOf('/') === fullpath.length - 1)
       ? ''
@@ -137,7 +137,7 @@ function pathBasename (fullpath) {
 }
 
 function hasSuffix (path, suffixes) {
-  for (var i in suffixes) {
+  for (let i in suffixes) {
     if (path.indexOf(suffixes[i], path.length - suffixes[i].length) !== -1) {
       return true
     }
@@ -146,7 +146,7 @@ function hasSuffix (path, suffixes) {
 }
 
 function getResourceLink (filename, uri, base, suffix, otherSuffix) {
-  var link = filenameToBaseUri(filename, uri, base)
+  const link = filenameToBaseUri(filename, uri, base)
   if (link.endsWith(suffix)) {
     return link
   } else if (link.endsWith(otherSuffix)) {
@@ -157,7 +157,7 @@ function getResourceLink (filename, uri, base, suffix, otherSuffix) {
 }
 
 function parse (data, baseUri, contentType, callback) {
-  var graph = $rdf.graph()
+  const graph = $rdf.graph()
   try {
     return $rdf.parse(data, graph, baseUri, contentType, callback)
   } catch (err) {
@@ -195,7 +195,7 @@ function translate (stream, baseUri, from, to, callback) {
     to = 'text/turtle'
   }
 
-  var data = ''
+  let data = ''
   stream
     .on('data', function (chunk) {
       data += chunk
@@ -221,7 +221,7 @@ function stringToStream (string) {
 
     // Pull in a new chunk of text,
     // removing it from the string.
-    var chunk = string.slice(0, size)
+    const chunk = string.slice(0, size)
     string = string.slice(size)
 
     // Emit "chunk" from the stream.
@@ -244,7 +244,7 @@ function stripLineEndings (obj) {
 }
 
 function reqToPath (req) {
-  var ldp = req.app.locals.ldp
-  var root = ldp.multiuser ? ldp.root + req.hostname + '/' : ldp.root
+  const ldp = req.app.locals.ldp
+  const root = ldp.multiuser ? ldp.root + req.hostname + '/' : ldp.root
   return uriToFilename(req.path, root)
 }


### PR DESCRIPTION
Refactors code in ./lib to use block level scope (const, let) instead of function level scope (var).