### PR TITLE
Use block level scope instead of function level scope

### DIFF
--- a/bin/lib/init.js
+++ b/bin/lib/init.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const options = require('./options')
 const camelize = require('camelize')
 
-var questions = options
+let questions = options
   .map((option) => {
     if (!option.type) {
       if (option.flag) {
@@ -56,8 +56,8 @@ module.exports = function (program) {
           })
 
           // write config file
-          var config = JSON.stringify(camelize(answers), null, '  ')
-          var configPath = process.cwd() + '/config.json'
+          const config = JSON.stringify(camelize(answers), null, '  ')
+          const configPath = process.cwd() + '/config.json'
 
           fs.writeFile(configPath, config, (err) => {
             if (err) {

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -13,7 +13,7 @@ module.exports = function (program, server) {
   options
     .filter((option) => !option.hide)
     .forEach((option) => {
-      var name = '--' + option.name
+      let name = '--' + option.name
       if (!option.flag) {
         name += ' [value]'
       }


### PR DESCRIPTION
Refactors code in ./bin to use block level scope (const, let) instead of function level scope (var).