### PR TITLE
Prevent double slashes in the "service" link header

### DIFF
--- a/lib/handlers/options.js
+++ b/lib/handlers/options.js
@@ -1,5 +1,6 @@
 const addLink = require('../header').addLink
 const utils = require('../utils')
+const url = require('url')
 
 module.exports = handler
 
@@ -22,7 +23,7 @@ function linkAuthProvider (req, res) {
 }
 
 function linkServiceEndpoint (req, res) {
-  let serviceEndpoint = `${utils.getFullUri(req)}/.well-known/solid`
+  let serviceEndpoint = url.resolve(utils.getFullUri(req), '.well-known/solid')
   addLink(res, serviceEndpoint, 'service')
 }
 

--- a/test/integration/capability-discovery-test.js
+++ b/test/integration/capability-discovery-test.js
@@ -100,6 +100,12 @@ describe('API', () => {
           .expect('Link', /<https:\/\/localhost:5000>; rel="http:\/\/openid\.net\/specs\/connect\/1\.0\/issuer"/)
           .expect(204, done)
       })
+
+      it('should return a service Link header without multiple slashes', (done) => {
+        alice.options('/')
+          .expect('Link', /<.*[^/]\/\.well-known\/solid>; rel="service"/)
+          .expect(204, done)
+      })
     })
   })
 })


### PR DESCRIPTION
Resolves #634