### PR TITLE
Only use cookies in HTTPS mode

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -159,7 +159,7 @@ function initWebId (argv, app, ldp) {
 
   // Store the user's session key in a cookie
   // (for same-domain browsing by people only)
-  const useSecureCookies = argv.webid  // argv.webid forces https and secure cookies
+  const useSecureCookies = !!argv.sslKey // use secure cookies when over HTTPS
   const sessionHandler = session(sessionSettings(useSecureCookies, argv.host))
   app.use((req, res, next) => {
     sessionHandler(req, res, () => {


### PR DESCRIPTION
Enables sessions (needed for OIDC) over regular HTTP, for instance, when behind a reverse proxy.