### PR TITLE
Refactor LDP to use a modular store/backend

### DIFF
--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -2,7 +2,6 @@
 
 const options = require('./options')
 const fs = require('fs')
-const extend = require('extend')
 const { cyan, red, bold } = require('colorette')
 
 module.exports = function (program, server) {
@@ -23,7 +22,7 @@ module.exports = function (program, server) {
   start.option('-v, --verbose', 'Print the logs to console')
 
   start.action((opts) => {
-    let argv = extend({}, opts, { version: program.version() })
+    let argv = Object.assign({}, opts, { version: program.version() })
     let configFile = argv['configFile'] || './config.json'
 
     fs.readFile(configFile, (err, file) => {

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -11,7 +11,9 @@ module.exports = {
   'port': 8443,
   'serverUri': 'https://localhost:8443',
   'webid': true,
-  'dataBrowserPath': 'default'
+  'dataBrowserPath': 'default',
+  'suffixAcl': '.acl',
+  'suffixMeta': '.meta'
 
   // For use in Enterprises to configure a HTTP proxy for all outbound HTTP requests from the SOLID server (we use
   // https://www.npmjs.com/package/global-tunnel-ng).

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -44,8 +44,9 @@ function createApp (argv = {}) {
   const configPath = config.initConfigDir(argv)
   argv.templates = config.initTemplateDirs(configPath)
 
+  config.printDebugInfo(argv)
+
   const ldp = new LDP(argv)
-  ldp.printDebugInfo()
 
   const app = express()
 

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -45,6 +45,7 @@ function createApp (argv = {}) {
   argv.templates = config.initTemplateDirs(configPath)
 
   const ldp = new LDP(argv)
+  ldp.printDebugInfo()
 
   const app = express()
 

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -39,7 +39,8 @@ function createApp (argv = {}) {
   // Override default configs (defaults) with passed-in params (argv)
   argv = Object.assign({}, defaults, argv)
 
-  argv.host = SolidHost.from({ port: argv.port, serverUri: argv.serverUri })
+  const hostConfig = config.hostConfigFor(argv)
+  argv.host = SolidHost.from(hostConfig)
 
   const configPath = config.initConfigDir(argv)
   argv.templates = config.initTemplateDirs(configPath)

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -72,7 +72,7 @@ function createServer (argv, app) {
       cert: cert
     }, argv)
 
-    if (ldp.webid && ldp.auth === 'tls') {
+    if (argv.webid && argv.auth === 'tls') {
       credentials.requestCert = true
     }
 

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -13,7 +13,6 @@ function createServer (argv, app) {
   argv = argv || {}
   app = app || express()
   const ldpApp = createApp(argv)
-  const ldp = ldpApp.locals.ldp || {}
   let mount = argv.mount || '/'
   // Removing ending '/'
   if (mount.length > 1 &&
@@ -98,9 +97,9 @@ function createServer (argv, app) {
   }
 
   // Setup Express app
-  if (ldp.live) {
+  if (argv.live) {
     const solidWs = SolidWs(server, ldpApp)
-    ldpApp.locals.ldp.live = solidWs.publish.bind(solidWs)
+    ldpApp.locals.host.live = solidWs.publish.bind(solidWs)
   }
 
   return server

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -19,7 +19,7 @@ const error = require('../http-error')
 const RDFs = require('../ldp').RDF_MIME_TYPES
 
 function handler (req, res, next) {
-  const ldp = req.app.locals.ldp
+  const { ldp, host: hostConfig } = req.app.locals
   const includeBody = req.method === 'GET'
   const negotiator = new Negotiator(req)
   const baseUri = utils.getFullUri(req)
@@ -32,7 +32,7 @@ function handler (req, res, next) {
   res.header('MS-Author-Via', 'SPARQL')
 
   // Set live updates
-  if (ldp.live) {
+  if (hostConfig.live) {
     res.header('Updates-Via', utils.getBaseUri(req).replace(/^http/, 'ws'))
   }
 

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -61,7 +61,6 @@ class LDP {
     this.multiuser = options.multiuser
     this.webid = options.webid
     this.strictOrigin = options.strictOrigin
-    this.live = options.live
     this.errorPages = options.errorPages
     this.noErrorPages = options.noErrorPages
     this.errorHandler = options.errorHandler

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -35,7 +35,6 @@ const RDF_MIME_TYPES = [
 /**
  * @constructor
  * @param [options={}] {Object}
- * @param [options.auth]
  * @param [options.serverUri]
  * @param [options.dbPath]
  * @param [options.configPath]
@@ -54,7 +53,6 @@ const RDF_MIME_TYPES = [
 class LDP {
   constructor (options = {}) {
     options = Object.assign({}, defaults, options)
-    this.auth = options.auth
     this.serverUri = options.serverUri
     this.dbPath = options.dbPath
     this.configPath = options.configPath

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -32,6 +32,23 @@ const RDF_MIME_TYPES = [
   'application/x-turtle'
 ]
 
+/**
+ * @constructor
+ * @param [options={}] {Object}
+ * @param [options.root]
+ * @param [options.suffixAcl]
+ * @param [options.suffixMeta]
+ * @param [options.errorPages]
+ * @param [options.fileBrowser]
+ * @param [options.suppressDataBrowser]
+ * @param [options.dataBrowserPath]
+ * @param [options.webid]
+ * @param [options.auth]
+ * @param [options.idp]
+ * @param [options.proxy]
+ * @param [options.live]
+ * @param [options.store]
+ */
 class LDP {
   constructor (argv = {}) {
     extend(this, argv)

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -84,10 +84,6 @@ class LDP {
       }
     }
 
-    if (this.skin !== false) {
-      this.skin = true
-    }
-
     if (this.corsProxy && this.corsProxy[ 0 ] !== '/') {
       this.corsProxy = '/' + this.corsProxy
     }

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -55,38 +55,18 @@ class LDP {
   constructor (options = {}) {
     Object.assign(this, options)
 
-    // Setting root
-    if (!this.root) {
-      this.root = process.cwd()
-    }
-    if (!this.root.endsWith('/')) {
-      this.root += '/'
-    }
-
-    // Suffixes
-    if (!this.suffixAcl) {
-      this.suffixAcl = '.acl'
-    }
-    if (!this.suffixMeta) {
-      this.suffixMeta = '.meta'
-    }
+    this.suffixAcl = options.suffixAcl || '.acl'
+    this.suffixMeta = options.suffixMeta || '.meta'
     this.turtleExtensions = [ '.ttl', this.suffixAcl, this.suffixMeta ]
 
-    // Error pages folder
-    this.errorPages = null
-    if (!this.noErrorPages) {
-      this.errorPages = options.errorPages
-      if (!this.errorPages) {
-        // TODO: For now disable error pages if errorPages parameter is not explicitly passed
-        this.noErrorPages = true
-      } else if (!this.errorPages.endsWith('/')) {
-        this.errorPages += '/'
-      }
-    }
+    this.root = options.root || process.cwd()
+    if (!this.root.endsWith('/')) { this.root += '/' }
 
-    if (this.corsProxy && this.corsProxy[ 0 ] !== '/') {
+    if (this.corsProxy && !this.corsProxy.startsWith('/')) {
       this.corsProxy = '/' + this.corsProxy
     }
+
+    this.initErrorPages(options)
   }
 
   printDebugInfo () {
@@ -102,6 +82,19 @@ class LDP {
     debug.settings('Multi-user: ' + !!this.multiuser)
     debug.settings('Suppress default data browser app: ' + this.suppressDataBrowser)
     debug.settings('Default data browser app file path: ' + this.dataBrowserPath)
+  }
+
+  initErrorPages (options) {
+    this.errorPages = null
+    if (!this.noErrorPages) {
+      this.errorPages = options.errorPages
+      if (!this.errorPages) {
+        // TODO: For now disable error pages if errorPages parameter is not explicitly passed
+        this.noErrorPages = true
+      } else if (!this.errorPages.endsWith('/')) {
+        this.errorPages += '/'
+      }
+    }
   }
 
   stat (file, callback) {

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -47,8 +47,6 @@ const RDF_MIME_TYPES = [
  * @param [options.dataBrowserPath]
  * @param [options.webid]
  * @param [options.multiuser]
- * @param [options.live]
- * @param [options.corsProxy]
  */
 class LDP {
   constructor (options = {}) {
@@ -71,10 +69,6 @@ class LDP {
 
     this.root = options.root || process.cwd()
     if (!this.root.endsWith('/')) { this.root += '/' }
-
-    if (this.corsProxy && !this.corsProxy.startsWith('/')) {
-      this.corsProxy = '/' + this.corsProxy
-    }
 
     this.initErrorPages(options)
   }

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -10,7 +10,6 @@ const utils = require('./utils')
 const error = require('./http-error')
 const stringToStream = require('./utils').stringToStream
 const serialize = require('./utils').serialize
-const extend = require('extend')
 const rimraf = require('rimraf')
 const ldpContainer = require('./ldp-container')
 const parse = require('./utils').parse
@@ -53,8 +52,8 @@ const RDF_MIME_TYPES = [
  * @param [options.store]
  */
 class LDP {
-  constructor (argv = {}) {
-    extend(this, argv)
+  constructor (options = {}) {
+    Object.assign(this, options)
 
     // Setting root
     if (!this.root) {
@@ -76,7 +75,7 @@ class LDP {
     // Error pages folder
     this.errorPages = null
     if (!this.noErrorPages) {
-      this.errorPages = argv.errorPages
+      this.errorPages = options.errorPages
       if (!this.errorPages) {
         // TODO: For now disable error pages if errorPages parameter is not explicitly passed
         this.noErrorPages = true

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -35,6 +35,9 @@ const RDF_MIME_TYPES = [
 /**
  * @constructor
  * @param [options={}] {Object}
+ * @param [options.serverUri]
+ * @param [options.dbPath]
+ * @param [options.configPath]
  * @param [options.root]
  * @param [options.suffixAcl]
  * @param [options.suffixMeta]
@@ -44,7 +47,7 @@ const RDF_MIME_TYPES = [
  * @param [options.dataBrowserPath]
  * @param [options.webid]
  * @param [options.auth]
- * @param [options.idp]
+ * @param [options.multiuser]
  * @param [options.proxy]
  * @param [options.live]
  * @param [options.store]
@@ -89,7 +92,9 @@ class LDP {
     if (this.corsProxy && this.corsProxy[ 0 ] !== '/') {
       this.corsProxy = '/' + this.corsProxy
     }
+  }
 
+  printDebugInfo () {
     debug.settings('Server URI: ' + this.serverUri)
     debug.settings('Auth method: ' + this.auth)
     debug.settings('Db path: ' + this.dbPath)
@@ -102,8 +107,6 @@ class LDP {
     debug.settings('Multi-user: ' + !!this.multiuser)
     debug.settings('Suppress default data browser app: ' + this.suppressDataBrowser)
     debug.settings('Default data browser app file path: ' + this.dataBrowserPath)
-
-    return this
   }
 
   stat (file, callback) {

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -15,6 +15,7 @@ const ldpContainer = require('./ldp-container')
 const parse = require('./utils').parse
 const fetch = require('node-fetch')
 const { promisify } = require('util')
+const defaults = require('../config/defaults')
 
 const DEFAULT_CONTENT_TYPE = 'text/turtle'
 
@@ -34,6 +35,7 @@ const RDF_MIME_TYPES = [
 /**
  * @constructor
  * @param [options={}] {Object}
+ * @param [options.auth]
  * @param [options.serverUri]
  * @param [options.dbPath]
  * @param [options.configPath]
@@ -45,18 +47,29 @@ const RDF_MIME_TYPES = [
  * @param [options.suppressDataBrowser]
  * @param [options.dataBrowserPath]
  * @param [options.webid]
- * @param [options.auth]
  * @param [options.multiuser]
- * @param [options.proxy]
  * @param [options.live]
- * @param [options.store]
+ * @param [options.corsProxy]
  */
 class LDP {
   constructor (options = {}) {
-    Object.assign(this, options)
+    options = Object.assign({}, defaults, options)
+    this.auth = options.auth
+    this.serverUri = options.serverUri
+    this.dbPath = options.dbPath
+    this.configPath = options.configPath
+    this.suffixAcl = options.suffixAcl
+    this.suffixMeta = options.suffixMeta
+    this.multiuser = options.multiuser
+    this.webid = options.webid
+    this.strictOrigin = options.strictOrigin
+    this.live = options.live
+    this.errorPages = options.errorPages
+    this.noErrorPages = options.noErrorPages
+    this.errorHandler = options.errorHandler
+    this.dataBrowserPath = options.dataBrowserPath
+    this.suppressDataBrowser = options.suppressDataBrowser
 
-    this.suffixAcl = options.suffixAcl || '.acl'
-    this.suffixMeta = options.suffixMeta || '.meta'
     this.turtleExtensions = [ '.ttl', this.suffixAcl, this.suffixMeta ]
 
     this.root = options.root || process.cwd()

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -69,21 +69,6 @@ class LDP {
     this.initErrorPages(options)
   }
 
-  printDebugInfo () {
-    debug.settings('Server URI: ' + this.serverUri)
-    debug.settings('Auth method: ' + this.auth)
-    debug.settings('Db path: ' + this.dbPath)
-    debug.settings('Config path: ' + this.configPath)
-    debug.settings('Suffix Acl: ' + this.suffixAcl)
-    debug.settings('Suffix Meta: ' + this.suffixMeta)
-    debug.settings('Filesystem Root: ' + this.root)
-    debug.settings('Allow WebID authentication: ' + !!this.webid)
-    debug.settings('Live-updates: ' + !!this.live)
-    debug.settings('Multi-user: ' + !!this.multiuser)
-    debug.settings('Suppress default data browser app: ' + this.suppressDataBrowser)
-    debug.settings('Default data browser app file path: ' + this.dataBrowserPath)
-  }
-
   initErrorPages (options) {
     this.errorPages = null
     if (!this.noErrorPages) {

--- a/lib/models/solid-host.js
+++ b/lib/models/solid-host.js
@@ -24,6 +24,8 @@ class SolidHost {
     this.parsedUri = url.parse(this.serverUri)
     this.host = this.parsedUri.host
     this.hostname = this.parsedUri.hostname
+
+    this.live = options.live
   }
 
   /**

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -5,6 +5,22 @@
 
 const fs = require('fs-extra')
 const path = require('path')
+const debug = require('./debug')
+
+function printDebugInfo (options) {
+  debug.settings('Server URI: ' + options.serverUri)
+  debug.settings('Auth method: ' + options.auth)
+  debug.settings('Db path: ' + options.dbPath)
+  debug.settings('Config path: ' + options.configPath)
+  debug.settings('Suffix Acl: ' + options.suffixAcl)
+  debug.settings('Suffix Meta: ' + options.suffixMeta)
+  debug.settings('Filesystem Root: ' + options.root)
+  debug.settings('Allow WebID authentication: ' + !!options.webid)
+  debug.settings('Live-updates: ' + !!options.live)
+  debug.settings('Multi-user: ' + !!options.multiuser)
+  debug.settings('Suppress default data browser app: ' + options.suppressDataBrowser)
+  debug.settings('Default data browser app file path: ' + options.dataBrowserPath)
+}
 
 /**
  * Ensures that a directory has been copied / initialized. Used to ensure that
@@ -132,5 +148,6 @@ module.exports = {
   ensureWelcomePage,
   initConfigDir,
   initDefaultViews,
-  initTemplateDirs
+  initTemplateDirs,
+  printDebugInfo
 }

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -22,6 +22,14 @@ function printDebugInfo (options) {
   debug.settings('Default data browser app file path: ' + options.dataBrowserPath)
 }
 
+function hostConfigFor (argv) {
+  return {
+    port: argv.port,
+    serverUri: argv.serverUri,
+    live: argv.live
+  }
+}
+
 /**
  * Ensures that a directory has been copied / initialized. Used to ensure that
  * account templates, email templates and default apps have been copied from
@@ -146,6 +154,7 @@ function initTemplateDirs (configPath) {
 module.exports = {
   ensureDirCopyExists,
   ensureWelcomePage,
+  hostConfigFor,
   initConfigDir,
   initDefaultViews,
   initTemplateDirs,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "express": "^4.16.3",
     "express-handlebars": "^3.0.0",
     "express-session": "^1.15.6",
-    "extend": "^3.0.0",
     "from2": "^2.1.0",
     "fs-extra": "^2.1.0",
     "glob": "^7.1.1",


### PR DESCRIPTION
This is an in-place refactoring of the LDP backend code, to be able to move towards the architecture outlined here: [Solid HTTP request handling flow](https://github.com/solid/solid-architecture/blob/master/server/request-flow.md).

To make the code review burden easier, it'll be done as a series of smaller PRs *into* this branch.

Addresses issue https://github.com/solid/node-solid-server/issues/483