### PR TITLE
Use SolidHost as server config (instead of LDP instance)

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -38,7 +38,8 @@ function createApp (argv = {}) {
   // Override default configs (defaults) with passed-in params (argv)
   argv = Object.assign({}, defaults, argv)
 
-  argv.host = SolidHost.from({ port: argv.port, serverUri: argv.serverUri })
+  const hostConfig = config.hostConfigFor(argv)
+  argv.host = SolidHost.from(hostConfig)
 
   const configPath = config.initConfigDir(argv)
   argv.templates = config.initTemplateDirs(configPath)

--- a/lib/create-server.js
+++ b/lib/create-server.js
@@ -13,7 +13,6 @@ function createServer (argv, app) {
   argv = argv || {}
   app = app || express()
   const ldpApp = createApp(argv)
-  const ldp = ldpApp.locals.ldp || {}
   let mount = argv.mount || '/'
   // Removing ending '/'
   if (mount.length > 1 &&
@@ -99,9 +98,9 @@ function createServer (argv, app) {
   }
 
   // Setup Express app
-  if (ldp.live) {
+  if (argv.live) {
     const solidWs = SolidWs(server, ldpApp)
-    ldpApp.locals.ldp.live = solidWs.publish.bind(solidWs)
+    ldpApp.locals.host.live = solidWs.publish.bind(solidWs)
   }
 
   return server

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -19,7 +19,7 @@ const error = require('../http-error')
 const RDFs = require('../ldp').RDF_MIME_TYPES
 
 function handler (req, res, next) {
-  const ldp = req.app.locals.ldp
+  const { ldp, host: hostConfig } = req.app.locals
   const includeBody = req.method === 'GET'
   const negotiator = new Negotiator(req)
   const baseUri = utils.getFullUri(req)
@@ -32,7 +32,7 @@ function handler (req, res, next) {
   res.header('MS-Author-Via', 'SPARQL')
 
   // Set live updates
-  if (ldp.live) {
+  if (hostConfig.live) {
     res.header('Updates-Via', utils.getBaseUri(req).replace(/^http/, 'ws'))
   }
 

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -45,8 +45,6 @@ const RDF_MIME_TYPES = [
  * @param [options.dataBrowserPath]
  * @param [options.webid]
  * @param [options.multiuser]
- * @param [options.live]
- * @param [options.corsProxy]
  */
 class LDP {
   constructor (options = {}) {
@@ -69,10 +67,6 @@ class LDP {
 
     this.root = options.root || process.cwd()
     if (!this.root.endsWith('/')) { this.root += '/' }
-
-    if (this.corsProxy && !this.corsProxy.startsWith('/')) {
-      this.corsProxy = '/' + this.corsProxy
-    }
 
     this.initErrorPages(options)
   }

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -59,7 +59,6 @@ class LDP {
     this.multiuser = options.multiuser
     this.webid = options.webid
     this.strictOrigin = options.strictOrigin
-    this.live = options.live
     this.errorPages = options.errorPages
     this.noErrorPages = options.noErrorPages
     this.errorHandler = options.errorHandler

--- a/lib/models/solid-host.js
+++ b/lib/models/solid-host.js
@@ -24,6 +24,8 @@ class SolidHost {
     this.parsedUri = url.parse(this.serverUri)
     this.host = this.parsedUri.host
     this.hostname = this.parsedUri.hostname
+
+    this.live = options.live
   }
 
   /**

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -22,6 +22,14 @@ function printDebugInfo (options) {
   debug.settings('Default data browser app file path: ' + options.dataBrowserPath)
 }
 
+function hostConfigFor (argv) {
+  return {
+    port: argv.port,
+    serverUri: argv.serverUri,
+    live: argv.live
+  }
+}
+
 /**
  * Ensures that a directory has been copied / initialized. Used to ensure that
  * account templates, email templates and default apps have been copied from
@@ -146,6 +154,7 @@ function initTemplateDirs (configPath) {
 module.exports = {
   ensureDirCopyExists,
   ensureWelcomePage,
+  hostConfigFor,
   initConfigDir,
   initDefaultViews,
   initTemplateDirs,


### PR DESCRIPTION
Currently, the LDP instance (via `req.app.locals.ldp`) is being used as a server config object.

Move that responsibility to the `SolidHost` instance.