### PR TITLE
Make per-origin .well-known folder

### DIFF
--- a/default-templates/new-account/.well-known/.acl
+++ b/default-templates/new-account/.well-known/.acl
@@ -1,0 +1,19 @@
+# ACL resource for the well-known folder
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+# The owner has all permissions
+<#owner>
+    a acl:Authorization;
+    acl:agent <{{webId}}>;
+    acl:accessTo <./>;
+    acl:defaultForNew <./>;
+    acl:mode acl:Read, acl:Write, acl:Control.
+
+# The public has read permissions
+<#public>
+    a acl:Authorization;
+    acl:agentClass foaf:Agent;
+    acl:accessTo <./>;
+    acl:defaultForNew <./>;
+    acl:mode acl:Read.


### PR DESCRIPTION
This should add a .well-known folder with a corresponding .acl to allow the public to read. 

This should address Issue #708 . Was this what you had in mind  @RubenVerborgh .

Kjetil