### PR TITLE
Add .well-known folder and ACL for public access

### DIFF
--- a/default-templates/server/.well-known/.acl
+++ b/default-templates/server/.well-known/.acl
@@ -1,0 +1,15 @@
+# ACL for the default .well-known/ resource
+# Server operators will be able to override it as they wish
+# Public-readable
+
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<#public>
+    a acl:Authorization;
+
+    acl:agentClass foaf:Agent;  # everyone
+
+    acl:accessTo </.well-known/>;
+
+    acl:mode acl:Read.


### PR DESCRIPTION
This should add an [rfc5785](https://tools.ietf.org/html/rfc5785) ```/.well-known/``` folder to the server. This should address #708 . 

Just checking that I have understood it correctly, when [the ACL docs](https://www.w3.org/wiki/WebAccessControl) say

> An Authorization specifies access control modes for set of resources, and is applicable only if a 
> resource points in their HTTP header to an acl file that contains or includes the given rule.

for example, what happens is that e.g. a GET for ```/.well-known/acme-challenge/fooBar``` will respond with a Link header that points at the ```.acl``` included in this commit, and therefore, the ACL will apply also to ```/.well-known/acme-challenge/fooBar```?