### PR TITLE
Fix logging in with client certificate

### DIFF
--- a/default-views/auth/login-tls.hbs
+++ b/default-views/auth/login-tls.hbs
@@ -8,33 +8,3 @@
     {{> auth/auth-hidden-fields}}
   </div>
 </form>
-
-<script type="text/javascript">
-  const button = document.getElementById('login-tls')
-  button.addEventListener('click', function(event) {
-    event.preventDefault()
-    fetch('/login/tls', { method: 'POST', credentials: 'include' })
-      .then(function(response) {
-        const webId = response.headers.get('user')
-        const idp = new URL(webId).origin
-        const session = { authType: 'WebID-TLS', webId, idp }
-        const authClientNamespace = 'solid-auth-client'
-        let authClientStore
-        try {
-          authClientStore = JSON.parse(localStorage.getItem(authClientNamespace) || '{}')
-        } catch (err) {
-          authClientStore = {}
-        }
-        authClientStore.session = session
-        localStorage.setItem(authClientNamespace, JSON.stringify(authClientStore))
-        return response
-      })
-      .then(function(response) {
-        // Temporary solution to restore return URL
-        // until https://github.com/solid/oidc-auth-manager/issues/17 is resolved
-        const returnToUrl = localStorage.getItem('returnToUrl')
-        localStorage.removeItem('returnToUrl')
-        window.location.href = returnToUrl || '/'
-      })
-  })
-</script>

--- a/default-views/auth/login-tls.hbs
+++ b/default-views/auth/login-tls.hbs
@@ -1,4 +1,4 @@
-<form method="post" action="/login/tls">
+<form method="post" action="{{tlsUrl}}">
   <div class="form-group">
 
     <button type="submit" class="btn btn-primary" id="login-tls">

--- a/default-views/auth/login.hbs
+++ b/default-views/auth/login.hbs
@@ -33,6 +33,15 @@
   </div>
 </div>
 
+<script>
+  // Send return URL from localStorage to server through hidden redirect_uri field
+  const returnToUrl = localStorage.getItem('returnToUrl')
+  if (returnToUrl)
+    for (let redirect of document.getElementsByName("redirect_uri"))
+      redirect.value = returnToUrl
+  localStorage.removeItem('returnToUrl')
+</script>
+
 <div class="container">
   <div class="row">
     <div class="col-md-4">

--- a/default-views/auth/select-provider.hbs
+++ b/default-views/auth/select-provider.hbs
@@ -29,8 +29,8 @@
   </form>
 </div>
 <script>
-  // Temporary solution to preserve return URL
-  // until https://github.com/solid/oidc-auth-manager/issues/17 is resolved
+  // Preserve return URL in localStorage
+  // (Do this on the client, because there might be a URL fragment the server can't see)
   const locationUrl = new URL(location)
   const returnToUrl = locationUrl.searchParams.get('returnToUrl')
   localStorage.removeItem('returnToUrl')

--- a/lib/requests/login-request.js
+++ b/lib/requests/login-request.js
@@ -79,7 +79,7 @@ class LoginRequest extends AuthRequest {
   static get (req, res) {
     const request = LoginRequest.fromParams(req, res)
 
-    request.renderForm()
+    request.renderForm(null, req)
   }
 
   /**
@@ -159,7 +159,7 @@ class LoginRequest extends AuthRequest {
   postLoginUrl (validUser) {
     let uri
 
-    if (this.authQueryParams['client_id']) {
+    if (/token/.test(this.authQueryParams['response_type'])) {
       // Login request is part of an app's auth flow
       uri = this.authorizeUrl()
     } else if (validUser) {
@@ -183,13 +183,15 @@ class LoginRequest extends AuthRequest {
   /**
    * Renders the login form
    */
-  renderForm (error) {
+  renderForm (error, req) {
+    let queryString = req && req.url && req.url.replace(/[^?]+\?/, '') || ''
     let params = Object.assign({}, this.authQueryParams,
       {
         registerUrl: this.registerUrl(),
         returnToUrl: this.returnToUrl,
         enablePassword: this.localAuth.password,
-        enableTls: this.localAuth.tls
+        enableTls: this.localAuth.tls,
+        tlsUrl: `/login/tls?${encodeURIComponent(queryString)}`
       })
 
     if (error) {

--- a/lib/requests/login-request.js
+++ b/lib/requests/login-request.js
@@ -157,18 +157,13 @@ class LoginRequest extends AuthRequest {
    * @return {string}
    */
   postLoginUrl (validUser) {
-    let uri
-
+    // Login request is part of an app's auth flow
     if (/token/.test(this.authQueryParams['response_type'])) {
-      // Login request is part of an app's auth flow
-      uri = this.authorizeUrl()
+      return this.authorizeUrl()
+    // Login request is a user going to /login in browser
     } else if (validUser) {
-      // Login request is a user going to /login in browser
-      // uri = this.accountManager.accountUriFor(validUser.username)
-      uri = validUser.accountUri
+      return this.authQueryParams['redirect_uri'] || validUser.accountUri
     }
-
-    return uri
   }
 
   /**

--- a/lib/requests/login-request.js
+++ b/lib/requests/login-request.js
@@ -175,19 +175,6 @@ class LoginRequest extends AuthRequest {
    * Redirects the Login request to continue on the OIDC auth workflow.
    */
   redirectPostLogin (validUser) {
-    // TODO: Make the kludge below unnecessary (e.g., by separating OIDC and TLS auth).
-    // If we have arrived here in the WebID-TLS case,
-    // this means the client has done an AJAX POST request to /login/tls.
-    // If the WebID is external, and we send out a redirect to that external URL,
-    // there is a risk that this external URL returns a non-2xx response.
-    // This in turn makes the AJAX call on the client fail,
-    // and its success code is not executed because of that failure.
-    // To prevent this, we just reply a 204 for external WebIDs.
-    if (this.authMethod === TLS_AUTH && validUser.externalWebId) {
-      debug('Login successful with WebID-TLS')
-      return this.response.header('User', validUser.webId).status(204).send()
-    }
-
     let uri = this.postLoginUrl(validUser)
     debug('Login successful, redirecting to ', uri)
     this.response.redirect(uri)

--- a/test/unit/login-request-test.js
+++ b/test/unit/login-request-test.js
@@ -175,13 +175,13 @@ describe('LoginRequest', () => {
   })
 
   describe('redirectPostLogin()', () => {
-    it('should redirect to the /authorize url if client_id is present', () => {
+    it('should redirect to the /authorize url if response_type includes token', () => {
       let res = HttpMocks.createResponse()
-      let authUrl = 'https://localhost:8443/authorize?client_id=client123'
+      let authUrl = 'https://localhost:8443/authorize?response_type=token'
       let validUser = accountManager.userAccountFrom({ username: 'alice' })
 
       let authQueryParams = {
-        client_id: 'client123'
+        response_type: 'token'
       }
 
       let options = { accountManager, authQueryParams, response: res }


### PR DESCRIPTION
As described in https://github.com/solid/solid-auth-client/issues/50, there is a bug that results in an error “Cannot issue PoPToken - missing session key” for people logging in with a client certificate (in OIDC mode).

The root cause of this bug is a too tightly coupled design without clear interface boundaries, wherein several components assume knowledge about each other's internals. If those internals change, other things break—as has happened here.

The concrete problems in this case are:
- in a futile attempt to authenticate, node-solid-server was writing to the internal localStorage of solid-auth-client, the structure of which changed in solid-auth-client v2
- a variety of mechanisms are used to pass various parts of state from the login form to the OIDC libraries and back

This PR adds the following:
- let the server handle certificate authentication (32f9e7d3eb6eaaf853c65a08ac17c364ec29e268)
- create an additional mechanism to pass the return URL to the server (08aa6d3e4b34645776a0fce508d223fdb6a5bb5e and 20752d7f9409695b7919e945ca9893280a6949ea)

This is not a clean solution, but the fastest way to fix this issue.