### PR TITLE
Use latest solid-auth-client

### DIFF
--- a/default-templates/new-account/index.html
+++ b/default-templates/new-account/index.html
@@ -65,65 +65,18 @@
     </div>
   </section>
 </div>
-</body>
 <script src="/common/js/solid-auth-client.bundle.js"></script>
 <script type="text/javascript">
-  const popupUri = window.location.origin + '/common/popup.html'
-  const stateData = {
-    session: null
-  }
-  const state = new Proxy(stateData, {
-    set: (obj, prop, value) => {
-      obj[prop] = value
-      render()
-    }
+  const button = document.getElementById('session-action')
+  let loggedIn = false
+
+  solid.auth.trackSession(session => {
+    loggedIn = !!session
+    button.innerText = loggedIn ? 'Log out' : 'Log in'
   })
 
-  function main() {
-    // Render the session state
-    SolidAuthClient
-      .currentSession()
-      .then(saveSession)
-      .then(render)
-
-    // Add event listeners
-    const actionButton = sessionActionButton()
-    actionButton.addEventListener('click', takeSessionAction)
-  }
-
-  function saveSession(session) {
-    state.session = session
-    return session
-  }
-
-  function takeSessionAction() {
-    const { session } = state
-    const loggedIn = !!session
-    if (loggedIn) {
-      SolidAuthClient
-        .logout()
-        .then(saveSession)
-    } else {
-      SolidAuthClient
-        .popupLogin({ popupUri })
-        .then(saveSession)
-    }
-  }
-
-  function render() {
-    const { session } = state
-    const actionButton = sessionActionButton()
-    if (!session) {
-      actionButton.innerText = 'Log in'
-    } else {
-      actionButton.innerText = 'Log out'
-    }
-  }
-
-  function sessionActionButton() {
-    return document.getElementById('session-action')
-  }
-
-  document.addEventListener('DOMContentLoaded', main)
+  button.addEventListener('click', () =>
+    loggedIn ? solid.auth.logout() : solid.auth.popupLogin())
 </script>
+</body>
 </html>

--- a/default-views/auth/login-required.hbs
+++ b/default-views/auth/login-required.hbs
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Log in</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <script src="/common/js/solid-auth-client.bundle.js"></script>
 </head>
 <body>
 <div class="container">
@@ -20,17 +19,16 @@
     <button class="btn btn-primary" onclick="register()">Register</button>
   </div>
 </div>
+<script src="/common/js/solid-auth-client.bundle.js"></script>
 <script>
   async function login() {
-    // Log in through the popup
-    const popupUri = '/common/popup.html'
-    const session = await SolidAuthClient.popupLogin({ popupUri })
+    const session = await solid.auth.popupLogin()
     if (session) {
       // Make authenticated request to the server to establish a session cookie
-      const { status } = await SolidAuthClient.fetch(location)
+      const { status } = await solid.auth.fetch(location)
       if (status === 401) {
         alert(`Invalid login.\n\nDid you set ${session.idp} as your OIDC provider in your profile ${session.webId}?`);
-        await SolidAuthClient.logout();
+        await solid.auth.logout()
       }
       // Now that we have a cookie, reload to display the authenticated page
       location.reload()

--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -94,6 +94,9 @@ function middleware (oidc) {
     ['/common/js/', 'solid-auth-client/dist-lib/solid-auth-client.bundle.js.map']
   ]
   authAssets.map(([path, file]) => routeResolvedFile(router, path, file))
+  // Redirect for .well-known login popup location
+  router.get('/.well-known/solid/login',
+    (req, res) => res.redirect('/common/popup.html'))
 
   // Initialize the OIDC Identity Provider routes/api
   // router.get('/.well-known/openid-configuration', discover.bind(provider))

--- a/package-lock.json
+++ b/package-lock.json
@@ -5653,6 +5653,18 @@
                 "encoding": "^0.1.11",
                 "is-stream": "^1.0.1"
               }
+            },
+            "solid-auth-client": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/solid-auth-client/-/solid-auth-client-2.2.0.tgz",
+              "integrity": "sha512-jUHQ0/lGfcCR1SA3O0Vkz38IJps+rW6OgiK5yDETwYpx2RLy1kqU50LNX2+YyNNFdMATPchvjcaO00Cz8CoSqQ==",
+              "requires": {
+                "@trust/oidc-rp": "^0.4.3",
+                "auth-header": "^0.3.1",
+                "commander": "^2.11.0",
+                "isomorphic-fetch": "^2.2.1",
+                "uuid": "^3.1.0"
+              }
             }
           }
         }
@@ -6281,6 +6293,18 @@
           "requires": {
             "encoding": "^0.1.11",
             "is-stream": "^1.0.1"
+          }
+        },
+        "solid-auth-client": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/solid-auth-client/-/solid-auth-client-2.2.0.tgz",
+          "integrity": "sha512-jUHQ0/lGfcCR1SA3O0Vkz38IJps+rW6OgiK5yDETwYpx2RLy1kqU50LNX2+YyNNFdMATPchvjcaO00Cz8CoSqQ==",
+          "requires": {
+            "@trust/oidc-rp": "^0.4.3",
+            "auth-header": "^0.3.1",
+            "commander": "^2.11.0",
+            "isomorphic-fetch": "^2.2.1",
+            "uuid": "^3.1.0"
           }
         }
       }
@@ -7330,11 +7354,10 @@
       }
     },
     "solid-auth-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/solid-auth-client/-/solid-auth-client-2.1.1.tgz",
-      "integrity": "sha512-F58ea/Kni0hbB8EcDk0v0HpVjHuJ6eAT8xvm5QRI9Sm+j5bEgoZJL+TNXpowKXvITcFcqOFMPWR3FeCoGeQQww==",
+      "version": "2.2.1-rc.0",
+      "resolved": "https://registry.npmjs.org/solid-auth-client/-/solid-auth-client-2.2.1-rc.0.tgz",
+      "integrity": "sha512-ylzuWE/NFTd66KsYVczJzHJb/JI8aOQJirhXZoPsk1vrfm0STYZU6fo+1dmTSY3I2NSfQkEBleX+WVSithJMSA==",
       "requires": {
-        "@trust/oidc-rp": "^0.4.3",
         "auth-header": "^0.3.1",
         "commander": "^2.11.0",
         "isomorphic-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rdflib": "^0.17.0",
     "recursive-readdir": "^2.1.0",
     "rimraf": "^2.5.0",
-    "solid-auth-client": "^2.1.1",
+    "solid-auth-client": "^2.2.1-rc.0",
     "solid-namespace": "^0.1.0",
     "solid-permissions": "^0.6.0",
     "solid-ws": "^0.2.3",


### PR DESCRIPTION
In addition to the latest fixes, this also allows us to considerably simplify our client-side scripts. (Note that the existing scripts continue working though.)

There's currently one drawback, and that is that `localStorage` needs to be cleared because the popup location changed. Will try to address that in solid-auth-client.