### PR TITLE
Communicate an originsAllowed from config

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -12,6 +12,7 @@ module.exports = {
   'serverUri': 'https://localhost:8443',
   'webid': true,
   'strictOrigin': true,
+  'originsAllowed': ['https://apps.solid.invalid'],
   'dataBrowserPath': 'default'
 
   // For use in Enterprises to configure a HTTP proxy for all outbound HTTP requests from the SOLID server (we use

--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -16,6 +16,7 @@ class ACLChecker {
     this.fetch = options.fetch
     this.fetchGraph = options.fetchGraph
     this.strictOrigin = options.strictOrigin
+    this.originsAllowed = options.originsAllowed
     this.suffix = options.suffix || DEFAULT_ACL_SUFFIX
   }
 
@@ -112,6 +113,7 @@ class ACLChecker {
       origin: this.origin,
       rdf: rdf,
       strictOrigin: this.strictOrigin,
+      originsAllowed: this.originsAllowed,
       isAcl: uri => this.isAcl(uri),
       aclUrlFor: uri => this.aclUrlFor(uri)
     }

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -48,7 +48,7 @@ function allow (mode) {
         },
         suffix: ldp.suffixAcl,
         strictOrigin: ldp.strictOrigin,
-	originsAllowed: ldp.originsAllowed
+        originsAllowed: ldp.originsAllowed
       })
 
       // Ensure the user has the required permission

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -47,7 +47,8 @@ function allow (mode) {
             .catch(() => ldp.fetchGraph(uri, options))
         },
         suffix: ldp.suffixAcl,
-        strictOrigin: ldp.strictOrigin
+        strictOrigin: ldp.strictOrigin,
+	originsAllowed: ldp.originsAllowed
       })
 
       // Ensure the user has the required permission

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -75,6 +75,8 @@ class LDP {
 
     debug.settings('Server URI: ' + this.serverUri)
     debug.settings('Auth method: ' + this.auth)
+    debug.settings('Strict origins: ' + this.strictOrigin)
+    debug.settings('Allowed origins: ' + this.originsAllowed)
     debug.settings('Db path: ' + this.dbPath)
     debug.settings('Config path: ' + this.configPath)
     debug.settings('Suffix Acl: ' + this.suffixAcl)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7787,21 +7787,26 @@
       }
     },
     "solid-permissions": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/solid-permissions/-/solid-permissions-0.6.0.tgz",
-      "integrity": "sha512-TiObEonB4l8VNa/6IOnNL0/7u3GKil4Bh/BiBB51AXOCuLahvTQ+LQc+C5KLHAykzyb9z5oM/BVOE3w8mzIm/A==",
+      "version": "0.7.0-beta.0",
+      "resolved": "https://registry.npmjs.org/solid-permissions/-/solid-permissions-0.7.0-beta.0.tgz",
+      "integrity": "sha512-ehbE1cVCP5A2qbxQkJghZ9BVHPGFVoppSUo/ay1wqeTVQLi4h1MzYv2WdP57gixztf5D/I/ugObk9LzupO8GOg==",
       "requires": {
         "debug": "^3.1.0",
         "solid-namespace": "0.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^2.5.0",
     "solid-auth-client": "^2.2.3",
     "solid-namespace": "^0.1.0",
-    "solid-permissions": "^0.6.0",
+    "solid-permissions": "^0.7.0-beta.0",
     "solid-ws": "^0.2.3",
     "ulid": "^0.1.0",
     "uuid": "^3.0.0",

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -144,12 +144,7 @@ describe('Authentication API (OIDC)', () => {
         expect(cookie).to.match(/Secure/)
       })
 
-      /* Reflecting https://github.com/solid/web-access-control-spec#referring-to-origins-ie-web-apps
-       where the cookie implies that the user is logged in
-       */
-
       describe('and performing a subsequent request', () => {
-        // If the user is not logged on, then fail 401 Unauthenticated
         describe('without that cookie', () => {
           let response
           before(done => {
@@ -165,9 +160,23 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
-        // TODO User not authorized test here
+        describe('with that cookie and a non-matching origin', () => {
+          let response
+          before(done => {
+            alice.get('/')
+              .set('Cookie', cookie)
+              .set('Origin', bobServerUri)
+              .end((err, res) => {
+                response = res
+                done(err)
+              })
+          })
 
-        // If the Origin header is not present, the succeed 200 OK
+          it('should return a 401', () => {
+            expect(response).to.have.property('status', 401)
+          })
+        })
+
         describe('with that cookie but without origin', () => {
           let response
           before(done => {
@@ -184,7 +193,6 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
-        // Clear cut case
         describe('with that cookie and a matching origin', () => {
           let response
           before(done => {
@@ -202,7 +210,6 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
-        // If the Origin is allowed by the ACL, then succeed 200 OK
         describe('without that cookie but with a matching origin', () => {
           let response
           before(done => {
@@ -214,12 +221,10 @@ describe('Authentication API (OIDC)', () => {
               })
           })
 
-          it('should return a 200', () => {
-            expect(response).to.have.property('status', 200)
+          it('should return a 401', () => {
+            expect(response).to.have.property('status', 401)
           })
         })
-
-        // Fail 403 Origin Unauthorized
         describe('without that cookie and a matching origin', () => {
           let response
           before(done => {
@@ -231,26 +236,8 @@ describe('Authentication API (OIDC)', () => {
               })
           })
 
-          it('should return a 403', () => {
-            expect(response).to.have.property('status', 403)
-          })
-        })
-
-        // TODO Does this really make sense?
-        describe('with that cookie and a non-matching origin', () => {
-          let response
-          before(done => {
-            alice.get('/')
-              .set('Cookie', cookie)
-              .set('Origin', bobServerUri)
-              .end((err, res) => {
-                response = res
-                done(err)
-              })
-          })
-
-          it('should return a 403', () => {
-            expect(response).to.have.property('status', 403)
+          it('should return a 401', () => {
+            expect(response).to.have.property('status', 401)
           })
         })
       })

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -193,6 +193,7 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
+        // TODO: Are the next two tests correct?
         describe('with that cookie and a matching origin', () => {
           let response
           before(done => {
@@ -205,8 +206,8 @@ describe('Authentication API (OIDC)', () => {
               })
           })
 
-          it('should return a 200', () => {
-            expect(response).to.have.property('status', 200)
+          it('Returns 403 but should it?', () => {
+            expect(response).to.have.property('status', 403)
           })
         })
 
@@ -221,7 +222,7 @@ describe('Authentication API (OIDC)', () => {
               })
           })
 
-          it('should return a 401', () => {
+          it('Returns a 401, but should it?', () => {
             expect(response).to.have.property('status', 401)
           })
         })

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -144,7 +144,12 @@ describe('Authentication API (OIDC)', () => {
         expect(cookie).to.match(/Secure/)
       })
 
+      /* Reflecting https://github.com/solid/web-access-control-spec#referring-to-origins-ie-web-apps
+       where the cookie implies that the user is logged in
+       */
+
       describe('and performing a subsequent request', () => {
+        // If the user is not logged on, then fail 401 Unauthenticated
         describe('without that cookie', () => {
           let response
           before(done => {
@@ -160,23 +165,9 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
-        describe('with that cookie and a non-matching origin', () => {
-          let response
-          before(done => {
-            alice.get('/')
-              .set('Cookie', cookie)
-              .set('Origin', bobServerUri)
-              .end((err, res) => {
-                response = res
-                done(err)
-              })
-          })
+        // TODO User not authorized test here
 
-          it('should return a 401', () => {
-            expect(response).to.have.property('status', 401)
-          })
-        })
-
+        // If the Origin header is not present, the succeed 200 OK
         describe('with that cookie but without origin', () => {
           let response
           before(done => {
@@ -193,6 +184,7 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
+        // Clear cut case
         describe('with that cookie and a matching origin', () => {
           let response
           before(done => {
@@ -210,6 +202,7 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
+        // If the Origin is allowed by the ACL, then succeed 200 OK
         describe('without that cookie but with a matching origin', () => {
           let response
           before(done => {
@@ -221,10 +214,12 @@ describe('Authentication API (OIDC)', () => {
               })
           })
 
-          it('should return a 401', () => {
-            expect(response).to.have.property('status', 401)
+          it('should return a 200', () => {
+            expect(response).to.have.property('status', 200)
           })
         })
+
+        // Fail 403 Origin Unauthorized
         describe('without that cookie and a matching origin', () => {
           let response
           before(done => {
@@ -236,8 +231,26 @@ describe('Authentication API (OIDC)', () => {
               })
           })
 
-          it('should return a 401', () => {
-            expect(response).to.have.property('status', 401)
+          it('should return a 403', () => {
+            expect(response).to.have.property('status', 403)
+          })
+        })
+
+        // TODO Does this really make sense?
+        describe('with that cookie and a non-matching origin', () => {
+          let response
+          before(done => {
+            alice.get('/')
+              .set('Cookie', cookie)
+              .set('Origin', bobServerUri)
+              .end((err, res) => {
+                response = res
+                done(err)
+              })
+          })
+
+          it('should return a 403', () => {
+            expect(response).to.have.property('status', 403)
           })
         })
       })

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -194,7 +194,7 @@ describe('Authentication API (OIDC)', () => {
         })
 
         // TODO: Are the next two tests correct?
-        describe('with that cookie and a matching origin', () => {
+        describe('with that cookie and a this origin', () => {
           let response
           before(done => {
             alice.get('/')
@@ -211,7 +211,7 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
-        describe('without that cookie but with a matching origin', () => {
+        describe('without that cookie but with a this origin', () => {
           let response
           before(done => {
             alice.get('/')
@@ -222,7 +222,7 @@ describe('Authentication API (OIDC)', () => {
               })
           })
 
-          it('Returns a 401, but should it?', () => {
+          it('Should return a 401', () => {
             expect(response).to.have.property('status', 401)
           })
         })

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -209,6 +209,37 @@ describe('Authentication API (OIDC)', () => {
             expect(response).to.have.property('status', 200)
           })
         })
+
+        describe('without that cookie but with a matching origin', () => {
+          let response
+          before(done => {
+            alice.get('/')
+              .set('Origin', aliceServerUri)
+              .end((err, res) => {
+                response = res
+                done(err)
+              })
+          })
+
+          it('should return a 401', () => {
+            expect(response).to.have.property('status', 401)
+          })
+        })
+        describe('without that cookie and a matching origin', () => {
+          let response
+          before(done => {
+            alice.get('/')
+              .set('Origin', bobServerUri)
+              .end((err, res) => {
+                response = res
+                done(err)
+              })
+          })
+
+          it('should return a 401', () => {
+            expect(response).to.have.property('status', 401)
+          })
+        })
       })
     })
 


### PR DESCRIPTION
This should communicate an `originsAllowed` option all the way from the default config and up to the ACLchecker, which again passes it to the `PermissionSet`. Also adds some debugging.

Obviously, the actual trusted origin has to change once we have registered and agreed on domain for it.

We should perhaps have an integration test, but I figured I'd let you poke at it first. :-)