### PR TITLE
Fix code for Login redirect

### DIFF
--- a/lib/requests/login-request.js
+++ b/lib/requests/login-request.js
@@ -158,7 +158,8 @@ class LoginRequest extends AuthRequest {
    */
   postLoginUrl (validUser) {
     // Login request is part of an app's auth flow
-    if (/token/.test(this.authQueryParams['response_type'])) {
+//??    if (/token/.test(this.authQueryParams['response_type'])) {
+    if (/token|code/.test(this.authQueryParams['response_type'])) {
       return this.authorizeUrl()
     // Login request is a user going to /login in browser
     } else if (validUser) {

--- a/lib/requests/login-request.js
+++ b/lib/requests/login-request.js
@@ -158,7 +158,6 @@ class LoginRequest extends AuthRequest {
    */
   postLoginUrl (validUser) {
     // Login request is part of an app's auth flow
-//??    if (/token/.test(this.authQueryParams['response_type'])) {
     if (/token|code/.test(this.authQueryParams['response_type'])) {
       return this.authorizeUrl()
     // Login request is a user going to /login in browser


### PR DESCRIPTION
A response_type of 'code' needs to be recognized for relying parties using authorization flow.
OSDB uses the solid/oidc-rp library in this way.