### PR TITLE
Improve the error messaging for permissions

### DIFF
--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -122,7 +122,12 @@ function bin (argv, server) {
     app = solid.createServer(argv, server)
   } catch (e) {
     if (e.code === 'EACCES') {
-      console.log(colors.red.bold('ERROR'), 'You need root privileges to start on this port')
+      if (e.syscall === 'mkdir') {
+        console.log(colors.red.bold('ERROR'), `You need permissions to create '${e.path}' folder`)
+      }
+      else {
+        console.log(colors.red.bold('ERROR'), 'You need root privileges to start on this port')
+      }
       return 1
     }
     if (e.code === 'EADDRINUSE') {

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -124,8 +124,7 @@ function bin (argv, server) {
     if (e.code === 'EACCES') {
       if (e.syscall === 'mkdir') {
         console.log(colors.red.bold('ERROR'), `You need permissions to create '${e.path}' folder`)
-      }
-      else {
+      } else {
         console.log(colors.red.bold('ERROR'), 'You need root privileges to start on this port')
       }
       return 1


### PR DESCRIPTION
If an invalid setup with directory permissions happened, it doesn't mean an invalid port. It usually implies it is a setup error. Add the handling for the mkdir sys call.

Fixes #800
