### PR TITLE
Use default popup URI

### DIFF
--- a/static/databrowser.html
+++ b/static/databrowser.html
@@ -2,13 +2,9 @@
 <html id="docHTML">
 <head>
     <link type="text/css" rel="stylesheet" href="https://solid.github.io/solid-panes/style/tabbedtab.css" />
-    <script>
-      var $SOLID_GLOBAL_config = {
-        popupUri: window.location.origin + '/common/popup.html'
-      }
-    </script>
     <script type="text/javascript" src="/common/js/mashlib.min.js"></script>
     <script>
+      const $SOLID_GLOBAL_config = {}
       document.addEventListener('DOMContentLoaded', function () {
         const panes = require('mashlib')
         const UI = panes.UI


### PR DESCRIPTION
solid-auth-client supports a .well-known popup URI as a default, so it is not necessary to specify this popup.

Moreover, if we do specify this popup URI, we risk running into https://github.com/solid/solid-auth-client/issues/54

Also see https://github.com/solid/solid-ui/pull/43