### PR TITLE
refactor: replace colors with colorette

### DIFF
--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -3,7 +3,7 @@
 const options = require('./options')
 const fs = require('fs')
 const extend = require('extend')
-const colors = require('colors/safe')
+const { cyan, red, bold } = require('colorette')
 
 module.exports = function (program, server) {
   const start = program
@@ -29,7 +29,7 @@ module.exports = function (program, server) {
     fs.readFile(configFile, (err, file) => {
       // No file exists, not a problem
       if (err) {
-        console.log(colors.cyan.bold('TIP'), 'create a config.json: `$ solid init`')
+        console.log(cyan(bold('TIP')), 'create a config.json: `$ solid init`')
       } else {
         // Use flags with priority over config file
         const config = JSON.parse(file)
@@ -123,17 +123,17 @@ function bin (argv, server) {
   } catch (e) {
     if (e.code === 'EACCES') {
       if (e.syscall === 'mkdir') {
-        console.log(colors.red.bold('ERROR'), `You need permissions to create '${e.path}' folder`)
+        console.log(red(bold('ERROR')), `You need permissions to create '${e.path}' folder`)
       } else {
-        console.log(colors.red.bold('ERROR'), 'You need root privileges to start on this port')
+        console.log(red(bold('ERROR')), 'You need root privileges to start on this port')
       }
       return 1
     }
     if (e.code === 'EADDRINUSE') {
-      console.log(colors.red.bold('ERROR'), 'The port ' + argv.port + ' is already in use')
+      console.log(red(bold('ERROR')), 'The port ' + argv.port + ' is already in use')
       return 1
     }
-    console.log(colors.red.bold('ERROR'), e.message)
+    console.log(red(bold('ERROR')), e.message)
     return 1
   }
   app.listen(argv.port, function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1979,10 +1979,10 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colors": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+    "colorette": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.0.5.tgz",
+      "integrity": "sha512-7mcpZLRdXqHLaOhGfKaDD/K7UjLSp6MkrDT6DziQ/HKBxqV3G1yLZAc14UCP8bCQAJTbcvd4k6MGRVYUa4NmHw=="
     },
     "combine-source-map": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "body-parser": "^1.18.3",
     "busboy": "^0.2.12",
     "camelize": "^1.0.0",
-    "colors": "^1.1.2",
+    "colorette": "^1.0.5",
     "commander": "^2.9.0",
     "cors": "^2.7.1",
     "debug": "^2.6.9",


### PR DESCRIPTION
👋 Hello maintainers.

## Summary

This PR replaces colors with [colorette](https://github.com/jorgebucaran/colorette). Disclaimer: I'm the author of colorette. This is a refactor change and does not intend to introduce breaking changes. Please let me know if this looks good or not and if you'd like me to make any changes.

Colorette is both lighter and faster than the colors packages. It's also "safe" by default, it doesn't mutate the string prototype. Terminal color support is autodetected, so our console output will not contain unreadable symbols if the target terminal does not support color.

Tests and coverage are at 100%.

## Size Comparison

| Package | Size |
|-|-|
| `colors` |[![install size](https://packagephobia.now.sh/badge?p=colors)](https://packagephobia.now.sh/result?p=colors)|
| `colorette` | [![install size](https://packagephobia.now.sh/badge?p=colorette)](https://packagephobia.now.sh/result?p=colorette)|

## Runtime Performance

All tests run on a 2.4GHz Intel Core i7 CPU with 16 GB memory. Complete benchmark results [here](https://github.com/jorgebucaran/colorette#benchmark-results) and implementation [here](https://github.com/jorgebucaran/colorette/tree/master/bench).

```
# Using Styles
colors × 64,999 ops/sec
> colorette × 709,733 ops/sec

# Combining Styles
colors × 246,004 ops/sec
> colorette × 2,049,555 ops/sec

# Nesting Styles
colors × 144,403 ops/sec
> colorette × 389,825 ops/sec
```

