### PR TITLE
Add test case for dot separated usernames.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-server",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solid-server",
   "description": "Solid server on top of the file-system",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "author": {
     "name": "Tim Berners-Lee",
     "email": "timbl@w3.org"

--- a/test/unit/create-account-request-test.js
+++ b/test/unit/create-account-request-test.js
@@ -97,7 +97,8 @@ describe('CreateAccountRequest', () => {
         'a-',
         '9-',
         'alice--bob',
-        'alice bob'
+        'alice bob',
+        'alice.bob'
       ]
 
       let invalidUsernamesCount = 0


### PR DESCRIPTION
The proper validation logic has already been implemented as part of https://github.com/solid/node-solid-server/pull/818. This merely adds a test case to verify that https://github.com/solid/solid/issues/157 has been fixed.