### PR TITLE
Allow cookies from all subdomains

### DIFF
--- a/lib/models/solid-host.js
+++ b/lib/models/solid-host.js
@@ -72,12 +72,14 @@ class SolidHost {
   allowsSessionFor (userId, origin) {
     // Allow no user or an empty origin
     if (!userId || !origin) return true
-    // Allow the server's main domain
-    if (origin === this.serverUri) return true
-    // Allow the user's subdomain
-    const userIdHost = userId.replace(/([^:/])\/.*/, '$1')
-    if (origin === userIdHost) return true
-    // Disallow everything else
+    // Allow the server and subdomains
+    const originHost = getHostName(origin)
+    const serverHost = getHostName(this.serverUri)
+    if (originHost === serverHost) return true
+    if (originHost.endsWith('.' + serverHost)) return true
+    // Allow the user's own domain
+    const userHost = getHostName(userId)
+    if (originHost === userHost) return true
     return false
   }
 
@@ -107,6 +109,11 @@ class SolidHost {
 
     return cookieDomain
   }
+}
+
+function getHostName (origin) {
+  const match = origin.match(/^\w+:\/*([^/]+)/)
+  return match ? match[1] : ''
 }
 
 module.exports = SolidHost

--- a/test/unit/solid-host-test.js
+++ b/test/unit/solid-host-test.js
@@ -55,23 +55,23 @@ describe('SolidHost', () => {
     })
 
     it('should allow a userId with empty origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', '')).to.be.true
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', '')).to.be.true
     })
 
     it('should allow a userId with the user subdomain as origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://user.test.local')).to.be.true
-    })
-
-    it('should disallow a userId with another subdomain as origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://other.test.local')).to.be.false
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://user.own')).to.be.true
     })
 
     it('should allow a userId with the server domain as origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://test.local')).to.be.true
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://test.local')).to.be.true
+    })
+
+    it('should allow a userId with a server subdomain as origin', () => {
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://other.test.local')).to.be.true
     })
 
     it('should disallow a userId from a different domain', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://other.remote')).to.be.false
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://other.remote')).to.be.false
     })
   })
 


### PR DESCRIPTION
It seems that applying #793 has enabled a security mechanism (#526) that is too strong. (It is unclear why this security mechanism didn't kick in earlier.)

#526 rejects cookies as authentication mechanism from other hosts, requiring other hosts to always send a Bearer header.

However, its definition of "other hosts" did not include subdomains. For example:
- https://alice.solid.community would not be trusted to send a login cookie for https://my.self/#me by https://solid.community

This pull request changes things such that
- https://*.solid.community is trusted to send a login cookie for https://my.self/#me by https://solid.community
- https://my.self is trusted to send a login cookie for https://my.self/#me by https://solid.community

This addresses breakage in 4.1.4 and 4.1.5 caused by #793 as noted by @kidehen in https://github.com/solid/node-solid-server/pull/793#issuecomment-426341408