### PR TITLE
Block cookie auth from non-subdomains, but allow all other auth from everywhere

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -168,23 +168,27 @@ function initWebId (argv, app, ldp) {
   // (for same-domain browsing by people only)
   const useSecureCookies = !!argv.sslKey // use secure cookies when over HTTPS
   const sessionHandler = session(sessionSettings(useSecureCookies, argv.host))
+  app.use(sessionHandler)
+  // Reject cookies from third-party applications.
+  // Otherwise, when a user is logged in to their Solid server,
+  // any third-party application could perform authenticated requests
+  // without permission by including the credentials set by the Solid server.
   app.use((req, res, next) => {
-    sessionHandler(req, res, () => {
-      // Reject cookies from third-party applications.
-      // Otherwise, when a user is logged in to their Solid server,
-      // any third-party application could perform authenticated requests
-      // without permission by including the credentials set by the Solid server.
-      const origin = req.headers.origin
-      const userId = req.session.userId
-      if (!argv.host.allowsSessionFor(userId, origin)) {
-        debug(`Rejecting session for ${userId} from ${origin}`)
-        // Destroy session data
-        delete req.session.userId
-        // Ensure this modified session is not saved
-        req.session.save = (done) => done()
-      }
-      next()
-    })
+    const origin = req.headers.origin
+    const userId = req.session.userId
+    // Exception: allow logout requests from all third-party apps
+    // such that OIDC client can log out via cookie auth
+    // TODO: remove this exception when OIDC clients
+    // use Bearer token to authenticate instead of cookie
+    // (https://github.com/solid/node-solid-server/pull/835#issuecomment-426429003)
+    if (!argv.host.allowsSessionFor(userId, origin) && !isLogoutRequest(req)) {
+      debug(`Rejecting session for ${userId} from ${origin}`)
+      // Destroy session data
+      delete req.session.userId
+      // Ensure this modified session is not saved
+      req.session.save = (done) => done()
+    }
+    next()
   })
 
   let accountManager = AccountManager.from({
@@ -207,6 +211,15 @@ function initWebId (argv, app, ldp) {
   if (argv.multiuser) {
     app.use(vhost('*', LdpMiddleware(corsSettings)))
   }
+}
+
+/**
+ * Determines whether the given request is a logout request
+ */
+function isLogoutRequest (req) {
+  // TODO: this is a hack that hard-codes OIDC paths,
+  // this code should live in the OIDC module
+  return req.path === '/logout' || req.path === '/goodbye'
 }
 
 /**

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -168,7 +168,24 @@ function initWebId (argv, app, ldp) {
   // (for same-domain browsing by people only)
   const useSecureCookies = !!argv.sslKey // use secure cookies when over HTTPS
   const sessionHandler = session(sessionSettings(useSecureCookies, argv.host))
-  app.use(sessionHandler)
+  app.use((req, res, next) => {
+    sessionHandler(req, res, () => {
+      // Reject cookies from third-party applications.
+      // Otherwise, when a user is logged in to their Solid server,
+      // any third-party application could perform authenticated requests
+      // without permission by including the credentials set by the Solid server.
+      const origin = req.headers.origin
+      const userId = req.session.userId
+      if (!argv.host.allowsSessionFor(userId, origin)) {
+        debug(`Rejecting session for ${userId} from ${origin}`)
+        // Destroy session data
+        delete req.session.userId
+        // Ensure this modified session is not saved
+        req.session.save = (done) => done()
+      }
+      next()
+    })
+  })
 
   let accountManager = AccountManager.from({
     authMethod: argv.auth,
@@ -187,25 +204,6 @@ function initWebId (argv, app, ldp) {
   // Set up authentication-related API endpoints and app.locals
   initAuthentication(app, argv)
 
-  // Protect against requests from third-party applications
-  app.use((req, res, next) => {
-    // Reject cookies from third-party applications.
-    // Otherwise, when a user is logged in to their Solid server,
-    // any third-party application could perform authenticated requests
-    // without permission by including the credentials set by the Solid server.
-    const origin = req.headers.origin
-    const userId = req.session.userId
-    if (!argv.host.allowsSessionFor(userId, origin)) {
-      debug(`Rejecting session for ${userId} from ${origin}`)
-      // Destroy session data
-      delete req.session.userId
-      // Ensure this modified session is not saved
-      req.session.save = done => done()
-    }
-    next()
-  })
-
-  // Set up per-host LDP middleware
   if (argv.multiuser) {
     app.use(vhost('*', LdpMiddleware(corsSettings)))
   }

--- a/lib/models/solid-host.js
+++ b/lib/models/solid-host.js
@@ -72,12 +72,14 @@ class SolidHost {
   allowsSessionFor (userId, origin) {
     // Allow no user or an empty origin
     if (!userId || !origin) return true
-    // Allow the server's main domain
-    if (origin === this.serverUri) return true
-    // Allow the user's subdomain
-    const userIdHost = userId.replace(/([^:/])\/.*/, '$1')
-    if (origin === userIdHost) return true
-    // Disallow everything else
+    // Allow the server and subdomains
+    const originHost = getHostName(origin)
+    const serverHost = getHostName(this.serverUri)
+    if (originHost === serverHost) return true
+    if (originHost.endsWith('.' + serverHost)) return true
+    // Allow the user's own domain
+    const userHost = getHostName(userId)
+    if (originHost === userHost) return true
     return false
   }
 
@@ -107,6 +109,11 @@ class SolidHost {
 
     return cookieDomain
   }
+}
+
+function getHostName (url) {
+  const match = url.match(/^\w+:\/*([^/]+)/)
+  return match ? match[1] : ''
 }
 
 module.exports = SolidHost

--- a/test/unit/solid-host-test.js
+++ b/test/unit/solid-host-test.js
@@ -55,23 +55,23 @@ describe('SolidHost', () => {
     })
 
     it('should allow a userId with empty origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', '')).to.be.true
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', '')).to.be.true
     })
 
     it('should allow a userId with the user subdomain as origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://user.test.local')).to.be.true
-    })
-
-    it('should disallow a userId with another subdomain as origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://other.test.local')).to.be.false
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://user.own')).to.be.true
     })
 
     it('should allow a userId with the server domain as origin', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://test.local')).to.be.true
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://test.local')).to.be.true
+    })
+
+    it('should allow a userId with a server subdomain as origin', () => {
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://other.test.local')).to.be.true
     })
 
     it('should disallow a userId from a different domain', () => {
-      expect(host.allowsSessionFor('https://user.test.local/profile/card#me', 'https://other.remote')).to.be.false
+      expect(host.allowsSessionFor('https://user.own/profile/card#me', 'https://other.remote')).to.be.false
     })
   })
 


### PR DESCRIPTION
#834 overreached, since it applied the cross-domain cookie ban from #793 to all auth methods, not just the cookie-base auth method.

The implementation currently contains a level-breaking hack, where the general module needs to know about the OIDC logout paths. A proper fix would require a more intense refactoring, where cookie-based auth is seen as a third method in addition to WebID-TLS and WebID-OIDC, not as part of either.

Also, we should note that this fix (as did #834) allows _any_ third party app to log the user out without their explicit permission if they happen to know the user's pod.