### PR TITLE
Remove old /logout bindings

### DIFF
--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -80,9 +80,6 @@ function middleware (oidc) {
   router.get('/account/password/change', PasswordChangeRequest.get)
   router.post('/account/password/change', bodyParser, PasswordChangeRequest.post)
 
-  router.get('/logout', LogoutRequest.handle)
-  router.post('/logout', LogoutRequest.handle)
-
   router.get('/goodbye', (req, res) => { res.render('auth/goodbye') })
 
   // The relying party callback is called at the end of the OIDC signin process

--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -13,8 +13,7 @@ const PasswordResetEmailRequest = require('../../requests/password-reset-email-r
 const PasswordChangeRequest = require('../../requests/password-change-request')
 
 const {
-  AuthCallbackRequest,
-  LogoutRequest
+  AuthCallbackRequest
 } = require('@solid/oidc-auth-manager').handlers
 
 /**


### PR DESCRIPTION
This PR relates to:

  * https://github.com/solid/oidc-op/issues/10#issuecomment-426233886
  * https://github.com/solid/oidc-op/issues/10#issuecomment-426602431

It makes the Solid OP's /logout endpoint invoke RPInitiatedLogoutRequest#handle instead of LogoutRequest#handle. See also: https://github.com/solid/oidc-op/pull/11