### PR TITLE
Add a repeat password field and give a visual feedback on the strength

### DIFF
--- a/common/css/server.css
+++ b/common/css/server.css
@@ -1,4 +1,0 @@
-.panel-login-tls,
-.panel-already-registered{
-    text-align: center;
-}

--- a/common/css/solid.css
+++ b/common/css/solid.css
@@ -1,0 +1,50 @@
+.panel-login-tls,
+.panel-already-registered{
+    text-align: center;
+}
+
+/**
+ * Password Strength
+ */
+
+/* Remove the bottom border on the input to make the progress bar like a part of it */
+.control-progress{
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom: 0;
+}
+
+/* Remove the top border on the progress bar to make the bar part of the input */
+.form-group .progress{
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    height: 7px;
+    margin-bottom: 0;
+}
+
+.form-group .progress-bar{
+    width: 0;
+}
+
+/**
+ * Password strength levels sizes for the progress bar
+ */
+.progress .level-0{
+    width: 5%
+}
+
+.progress .level-1{
+    width: 25%;
+}
+
+.progress .level-2{
+    width: 50%;
+}
+
+.progress .level-3{
+    width: 75%;
+}
+
+.progress .level-4{
+    width: 100%;
+}

--- a/common/js/solid.js
+++ b/common/js/solid.js
@@ -1,8 +1,8 @@
-/* global owaspPasswordStrengthTest, TextEncoder, crypto */
+/* global owaspPasswordStrengthTest, TextEncoder, crypto, fetch */
 (function () {
   'use strict'
 
-  var PasswordValidator = function (passwordField, repeatedPasswordField) {
+  const PasswordValidator = function (passwordField, repeatedPasswordField) {
     if (
       passwordField === null || passwordField === undefined ||
       repeatedPasswordField === null || repeatedPasswordField === undefined
@@ -20,23 +20,23 @@
     this.errors = []
   }
 
-  PasswordValidator.prototype.FEEDBACK_SUCCESS = 'success'
-  PasswordValidator.prototype.FEEDBACK_WARNING = 'warning'
-  PasswordValidator.prototype.FEEDBACK_ERROR = 'error'
+  const FEEDBACK_SUCCESS = 'success'
+  const FEEDBACK_WARNING = 'warning'
+  const FEEDBACK_ERROR = 'error'
 
-  PasswordValidator.prototype.ICON_SUCCESS = 'glyphicon-ok'
-  PasswordValidator.prototype.ICON_WARNING = 'glyphicon-warning-sign'
-  PasswordValidator.prototype.ICON_ERROR = 'glyphicon-remove'
+  const ICON_SUCCESS = 'glyphicon-ok'
+  const ICON_WARNING = 'glyphicon-warning-sign'
+  const ICON_ERROR = 'glyphicon-remove'
 
-  PasswordValidator.prototype.VALIDATION_SUCCESS = 'has-success'
-  PasswordValidator.prototype.VALIDATION_WARNING = 'has-warning'
-  PasswordValidator.prototype.VALIDATION_ERROR = 'has-error'
+  const VALIDATION_SUCCESS = 'has-success'
+  const VALIDATION_WARNING = 'has-warning'
+  const VALIDATION_ERROR = 'has-error'
 
-  PasswordValidator.prototype.STRENGTH_PROGRESS_0 = 'progress-bar-danger level-0'
-  PasswordValidator.prototype.STRENGTH_PROGRESS_1 = 'progress-bar-danger level-1'
-  PasswordValidator.prototype.STRENGTH_PROGRESS_2 = 'progress-bar-warning level-2'
-  PasswordValidator.prototype.STRENGTH_PROGRESS_3 = 'progress-bar-success level-3'
-  PasswordValidator.prototype.STRENGTH_PROGRESS_4 = 'progress-bar-success level-4'
+  const STRENGTH_PROGRESS_0 = 'progress-bar-danger level-0'
+  const STRENGTH_PROGRESS_1 = 'progress-bar-danger level-1'
+  const STRENGTH_PROGRESS_2 = 'progress-bar-warning level-2'
+  const STRENGTH_PROGRESS_3 = 'progress-bar-success level-3'
+  const STRENGTH_PROGRESS_4 = 'progress-bar-success level-4'
 
   /**
    * Prefetch all dom nodes at initialisation in order to gain time at execution since DOM manipulations
@@ -77,8 +77,8 @@
    * Validate password on the fly to provide the user a visual strength meter
    */
   PasswordValidator.prototype.instantFeedbackForPassword = function () {
-    var passwordStrength = this.getPasswordStrength(this.passwordField.value)
-    var strengthLevel = this.getStrengthLevel(passwordStrength)
+    const passwordStrength = this.getPasswordStrength(this.passwordField.value)
+    const strengthLevel = this.getStrengthLevel(passwordStrength)
 
     if (this.currentStrengthLevel === strengthLevel) {
       return
@@ -98,8 +98,8 @@
    */
   PasswordValidator.prototype.validatePassword = function () {
     this.errors = []
-    var password = this.passwordField.value
-    var passwordStrength = this.getPasswordStrength(password)
+    const password = this.passwordField.value
+    const passwordStrength = this.getPasswordStrength(password)
     this.currentStrengthLevel = this.getStrengthLevel(passwordStrength)
 
     if (passwordStrength.errors) {
@@ -135,7 +135,7 @@
   }
 
   PasswordValidator.prototype.setPasswordFeedback = function () {
-    var feedback = this.getFeedbackFromLevel()
+    const feedback = this.getFeedbackFromLevel()
     this.updateStrengthMeter()
     this.displayPasswordErrors()
     this.setFeedbackForField(feedback, this.passwordField)
@@ -145,7 +145,7 @@
    * Update the repeated password feedback icon and color
    */
   PasswordValidator.prototype.updateRepeatedPasswordFeedback = function () {
-    var feedback = this.checkPasswordFieldsEquality() ? this.FEEDBACK_SUCCESS : this.FEEDBACK_ERROR
+    const feedback = this.checkPasswordFieldsEquality() ? FEEDBACK_SUCCESS : FEEDBACK_ERROR
     this.setFeedbackForField(feedback, this.repeatedPasswordField)
   }
 
@@ -155,8 +155,8 @@
    * @param {HTMLElement} field
    */
   PasswordValidator.prototype.setFeedbackForField = function (feedback, field) {
-    var formGroup = this.getFormGroupElementForField(field)
-    var visualFeedback = this.getFeedbackElementForField(field)
+    const formGroup = this.getFormGroupElementForField(field)
+    const visualFeedback = this.getFeedbackElementForField(field)
 
     this.resetValidation(formGroup)
     this.resetFeedbackIcon(visualFeedback)
@@ -218,10 +218,13 @@
     return 4
   }
 
-  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP = []
-  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[0] = PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[1] = PasswordValidator.prototype.FEEDBACK_ERROR
-  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[2] = PasswordValidator.prototype.FEEDBACK_WARNING
-  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[3] = PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[4] = PasswordValidator.prototype.FEEDBACK_SUCCESS
+  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP = [
+    FEEDBACK_ERROR,
+    FEEDBACK_ERROR,
+    FEEDBACK_WARNING,
+    FEEDBACK_SUCCESS,
+    FEEDBACK_SUCCESS
+  ]
 
   /**
    * @returns {string}
@@ -230,12 +233,13 @@
     return this.LEVEL_TO_FEEDBACK_MAP[this.currentStrengthLevel]
   }
 
-  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP = []
-  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[0] = PasswordValidator.prototype.STRENGTH_PROGRESS_0
-  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[1] = PasswordValidator.prototype.STRENGTH_PROGRESS_1
-  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[2] = PasswordValidator.prototype.STRENGTH_PROGRESS_2
-  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[3] = PasswordValidator.prototype.STRENGTH_PROGRESS_3
-  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[4] = PasswordValidator.prototype.STRENGTH_PROGRESS_4
+  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP = [
+    STRENGTH_PROGRESS_0,
+    STRENGTH_PROGRESS_1,
+    STRENGTH_PROGRESS_2,
+    STRENGTH_PROGRESS_3,
+    STRENGTH_PROGRESS_4
+  ]
 
   /**
    * Get the CSS class for the meter based on the current level
@@ -245,24 +249,28 @@
   }
 
   PasswordValidator.prototype.addPasswordError = function (error) {
-    if (Array.isArray(error)) {
-      for (var i = 0, ln = error.length; i < ln; i++) {
-        this.addPasswordError(error[i])
-      }
-      return
-    }
-
-    this.errors.push(error)
+    this.errors.push(...(Array.isArray(error) ? error : [error]))
   }
 
   PasswordValidator.prototype.displayPasswordErrors = function () {
-    this.passwordHelpText.innerHTML = '<p>' + this.errors.join('</p><p>') + '</p>'
+    // Erase the error list content
+    while (this.passwordHelpText.firstChild) {
+      this.passwordHelpText.removeChild(this.passwordHelpText.firstChild)
+    }
+
+    // Add the errors in the stack to the DOM
+    this.errors.map((error) => {
+      let text = document.createTextNode(error)
+      let paragraph = document.createElement('p')
+      paragraph.appendChild(text)
+      this.passwordHelpText.appendChild(paragraph)
+    })
   }
 
   PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP = []
-  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[PasswordValidator.prototype.FEEDBACK_SUCCESS] = PasswordValidator.prototype.ICON_SUCCESS
-  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[PasswordValidator.prototype.FEEDBACK_WARNING] = PasswordValidator.prototype.ICON_WARNING
-  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[PasswordValidator.prototype.FEEDBACK_ERROR] = PasswordValidator.prototype.ICON_ERROR
+  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[FEEDBACK_SUCCESS] = ICON_SUCCESS
+  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[FEEDBACK_WARNING] = ICON_WARNING
+  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[FEEDBACK_ERROR] = ICON_ERROR
 
   /**
    * @param success|error|warning feedback
@@ -272,9 +280,9 @@
   }
 
   PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP = []
-  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[PasswordValidator.prototype.FEEDBACK_SUCCESS] = PasswordValidator.prototype.VALIDATION_SUCCESS
-  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[PasswordValidator.prototype.FEEDBACK_WARNING] = PasswordValidator.prototype.VALIDATION_WARNING
-  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[PasswordValidator.prototype.FEEDBACK_ERROR] = PasswordValidator.prototype.VALIDATION_ERROR
+  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[FEEDBACK_SUCCESS] = VALIDATION_SUCCESS
+  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[FEEDBACK_WARNING] = VALIDATION_WARNING
+  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[FEEDBACK_ERROR] = VALIDATION_ERROR
 
   /**
    * @param success|error|warning feedback
@@ -300,12 +308,12 @@
    * @param password
    */
   PasswordValidator.prototype.checkLeakedPassword = function (password) {
-    var url = 'https://api.pwnedpasswords.com/range/'
+    const url = 'https://api.pwnedpasswords.com/range/'
 
     return new Promise(function (resolve, reject) {
       this.sha1(password).then((digest) => {
-        var preFix = digest.slice(0, 5)
-        var suffix = digest.slice(5, digest.length)
+        const preFix = digest.slice(0, 5)
+        let suffix = digest.slice(5, digest.length)
         suffix = suffix.toUpperCase()
 
         return fetch(url + preFix)
@@ -335,12 +343,11 @@
    * CSS Classes reseters
    */
 
-
   PasswordValidator.prototype.resetValidation = function (el) {
-    var tokenizedClasses = this.tokenize(
-      this.VALIDATION_ERROR,
-      this.VALIDATION_WARNING,
-      this.VALIDATION_SUCCESS
+    const tokenizedClasses = this.tokenize(
+      VALIDATION_ERROR,
+      VALIDATION_WARNING,
+      VALIDATION_SUCCESS
     )
 
     el.classList.remove.apply(
@@ -350,10 +357,10 @@
   }
 
   PasswordValidator.prototype.resetFeedbackIcon = function (el) {
-    var tokenizedClasses = this.tokenize(
-      this.ICON_ERROR,
-      this.ICON_WARNING,
-      this.ICON_SUCCESS
+    const tokenizedClasses = this.tokenize(
+      ICON_ERROR,
+      ICON_WARNING,
+      ICON_SUCCESS
     )
 
     el.classList.remove.apply(
@@ -363,11 +370,11 @@
   }
 
   PasswordValidator.prototype.resetStrengthMeter = function () {
-    var tokenizedClasses = this.tokenize(
-      this.STRENGTH_PROGRESS_1,
-      this.STRENGTH_PROGRESS_2,
-      this.STRENGTH_PROGRESS_3,
-      this.STRENGTH_PROGRESS_4
+    const tokenizedClasses = this.tokenize(
+      STRENGTH_PROGRESS_1,
+      STRENGTH_PROGRESS_2,
+      STRENGTH_PROGRESS_3,
+      STRENGTH_PROGRESS_4
     )
 
     this.passwordStrengthMeter.classList.remove.apply(
@@ -405,8 +412,8 @@
    * @returns {string[]}
    */
   PasswordValidator.prototype.tokenize = function () {
-    var tokenArray = []
-    for (var i in arguments) {
+    let tokenArray = []
+    for (let i in arguments) {
       tokenArray.push(arguments[i])
     }
     return tokenArray.join(' ').split(' ')
@@ -415,9 +422,9 @@
   PasswordValidator.prototype.sha1 = function (str) {
     let buffer = new TextEncoder('utf-8').encode(str)
 
-    return crypto.subtle.digest('SHA-1', buffer).then(function (hash) {
+    return crypto.subtle.digest('SHA-1', buffer).then((hash) => {
       return this.hex(hash)
-    }.bind(this))
+    })
   }
 
   PasswordValidator.prototype.hex = function (buffer) {

--- a/common/js/solid.js
+++ b/common/js/solid.js
@@ -1,0 +1,440 @@
+/* global owaspPasswordStrengthTest, TextEncoder, crypto */
+(function () {
+  'use strict'
+
+  var PasswordValidator = function (passwordField, repeatedPasswordField) {
+    if (
+      passwordField === null || passwordField === undefined ||
+      repeatedPasswordField === null || repeatedPasswordField === undefined
+    ) {
+      return
+    }
+
+    this.passwordField = passwordField
+    this.repeatedPasswordField = repeatedPasswordField
+
+    this.fetchDomNodes()
+    this.bindEvents()
+
+    this.currentStrengthLevel = 0
+    this.errors = []
+  }
+
+  PasswordValidator.prototype.FEEDBACK_SUCCESS = 'success'
+  PasswordValidator.prototype.FEEDBACK_WARNING = 'warning'
+  PasswordValidator.prototype.FEEDBACK_ERROR = 'error'
+
+  PasswordValidator.prototype.ICON_SUCCESS = 'glyphicon-ok'
+  PasswordValidator.prototype.ICON_WARNING = 'glyphicon-warning-sign'
+  PasswordValidator.prototype.ICON_ERROR = 'glyphicon-remove'
+
+  PasswordValidator.prototype.VALIDATION_SUCCESS = 'has-success'
+  PasswordValidator.prototype.VALIDATION_WARNING = 'has-warning'
+  PasswordValidator.prototype.VALIDATION_ERROR = 'has-error'
+
+  PasswordValidator.prototype.STRENGTH_PROGRESS_0 = 'progress-bar-danger level-0'
+  PasswordValidator.prototype.STRENGTH_PROGRESS_1 = 'progress-bar-danger level-1'
+  PasswordValidator.prototype.STRENGTH_PROGRESS_2 = 'progress-bar-warning level-2'
+  PasswordValidator.prototype.STRENGTH_PROGRESS_3 = 'progress-bar-success level-3'
+  PasswordValidator.prototype.STRENGTH_PROGRESS_4 = 'progress-bar-success level-4'
+
+  /**
+   * Prefetch all dom nodes at initialisation in order to gain time at execution since DOM manipulations
+   * are really time consuming
+   */
+  PasswordValidator.prototype.fetchDomNodes = function () {
+    this.form = this.passwordField.closest('form')
+
+    this.passwordGroup = this.passwordField.closest('.form-group')
+    this.passwordFeedback = this.passwordGroup.querySelector('.form-control-feedback')
+    this.passwordStrengthMeter = this.passwordGroup.querySelector('.progress-bar')
+    this.passwordHelpText = this.passwordGroup.querySelector('.help-block')
+
+    this.repeatedPasswordGroup = this.repeatedPasswordField.closest('.form-group')
+    this.repeatedPasswordFeedback = this.repeatedPasswordGroup.querySelector('.form-control-feedback')
+  }
+
+  PasswordValidator.prototype.bindEvents = function () {
+    this.passwordField.addEventListener('focus', this.resetPasswordFeedback.bind(this))
+    this.passwordField.addEventListener('keyup', this.instantFeedbackForPassword.bind(this))
+    this.repeatedPasswordField.addEventListener('keyup', this.validateRepeatedPassword.bind(this))
+    this.passwordField.addEventListener('blur', this.validatePassword.bind(this))
+  }
+
+  /**
+   * Events Listeners
+   */
+
+  PasswordValidator.prototype.resetPasswordFeedback = function () {
+    this.errors = []
+    this.resetValidation(this.passwordGroup)
+    this.resetFeedbackIcon(this.passwordFeedback)
+    this.displayPasswordErrors()
+    this.instantFeedbackForPassword()
+  }
+
+  /**
+   * Validate password on the fly to provide the user a visual strength meter
+   */
+  PasswordValidator.prototype.instantFeedbackForPassword = function () {
+    var passwordStrength = this.getPasswordStrength(this.passwordField.value)
+    var strengthLevel = this.getStrengthLevel(passwordStrength)
+
+    if (this.currentStrengthLevel === strengthLevel) {
+      return
+    }
+
+    this.currentStrengthLevel = strengthLevel
+
+    this.updateStrengthMeter()
+
+    if (this.repeatedPasswordField.value !== '') {
+      this.updateRepeatedPasswordFeedback()
+    }
+  }
+
+  /**
+   * Validate password and display the error(s) message(s)
+   */
+  PasswordValidator.prototype.validatePassword = function () {
+    this.errors = []
+    var password = this.passwordField.value
+    var passwordStrength = this.getPasswordStrength(password)
+    this.currentStrengthLevel = this.getStrengthLevel(passwordStrength)
+
+    if (passwordStrength.errors) {
+      this.addPasswordError(passwordStrength.errors)
+    }
+
+    this.checkLeakedPassword(password).then(this.handleLeakedPasswordResponse.bind(this))
+
+    this.setPasswordFeedback()
+  }
+
+  /**
+   * Validate the repeated password upon typing
+   */
+  PasswordValidator.prototype.validateRepeatedPassword = function () {
+    this.updateRepeatedPasswordFeedback()
+  }
+
+  /**
+   * User Feedback manipulators
+   */
+
+  /**
+   * Update the strength meter based on OWASP feedback
+   */
+  PasswordValidator.prototype.updateStrengthMeter = function () {
+    this.resetStrengthMeter()
+
+    this.passwordStrengthMeter.classList.add.apply(
+      this.passwordStrengthMeter.classList,
+      this.tokenize(this.getStrengthLevelProgressClass())
+    )
+  }
+
+  PasswordValidator.prototype.setPasswordFeedback = function () {
+    var feedback = this.getFeedbackFromLevel()
+    this.updateStrengthMeter()
+    this.displayPasswordErrors()
+    this.setFeedbackForField(feedback, this.passwordField)
+  }
+
+  /**
+   * Update the repeated password feedback icon and color
+   */
+  PasswordValidator.prototype.updateRepeatedPasswordFeedback = function () {
+    var feedback = this.checkPasswordFieldsEquality() ? this.FEEDBACK_SUCCESS : this.FEEDBACK_ERROR
+    this.setFeedbackForField(feedback, this.repeatedPasswordField)
+  }
+
+  /**
+   * Display the given feedback on the field
+   * @param {string} feedback success|error|warning
+   * @param {HTMLElement} field
+   */
+  PasswordValidator.prototype.setFeedbackForField = function (feedback, field) {
+    var formGroup = this.getFormGroupElementForField(field)
+    var visualFeedback = this.getFeedbackElementForField(field)
+
+    this.resetValidation(formGroup)
+    this.resetFeedbackIcon(visualFeedback)
+
+    visualFeedback.classList.remove('hidden')
+
+    visualFeedback.classList
+      .add
+      .apply(
+        visualFeedback.classList,
+        this.tokenize(this.getFeedbackIconClass(feedback))
+      )
+
+    formGroup.classList
+      .add
+      .apply(
+        formGroup.classList,
+        this.tokenize(this.getValidationClass(feedback))
+      )
+  }
+
+  /**
+   * Password Strength Helpers
+   */
+
+  /**
+   * Get OWASP feedback on the given password. Returns false if the password is empty
+   * @param password
+   * @returns {object|false}
+   */
+  PasswordValidator.prototype.getPasswordStrength = function (password) {
+    if (password === '') {
+      return false
+    }
+    return owaspPasswordStrengthTest.test(password)
+  }
+
+  /**
+   * Get the password strength level based on password strength feedback object given by OWASP
+   * @param passwordStrength
+   * @returns {number}
+   */
+  PasswordValidator.prototype.getStrengthLevel = function (passwordStrength) {
+    if (passwordStrength === false) {
+      return 0
+    }
+    if (passwordStrength.requiredTestErrors.length !== 0) {
+      return 1
+    }
+
+    if (passwordStrength.strong === false) {
+      return 2
+    }
+
+    if (passwordStrength.isPassphrase === false || passwordStrength.optionalTestErrors.length !== 0) {
+      return 3
+    }
+
+    return 4
+  }
+
+  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP = []
+  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[0] = PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[1] = PasswordValidator.prototype.FEEDBACK_ERROR
+  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[2] = PasswordValidator.prototype.FEEDBACK_WARNING
+  PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[3] = PasswordValidator.prototype.LEVEL_TO_FEEDBACK_MAP[4] = PasswordValidator.prototype.FEEDBACK_SUCCESS
+
+  /**
+   * @returns {string}
+   */
+  PasswordValidator.prototype.getFeedbackFromLevel = function () {
+    return this.LEVEL_TO_FEEDBACK_MAP[this.currentStrengthLevel]
+  }
+
+  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP = []
+  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[0] = PasswordValidator.prototype.STRENGTH_PROGRESS_0
+  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[1] = PasswordValidator.prototype.STRENGTH_PROGRESS_1
+  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[2] = PasswordValidator.prototype.STRENGTH_PROGRESS_2
+  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[3] = PasswordValidator.prototype.STRENGTH_PROGRESS_3
+  PasswordValidator.prototype.LEVEL_TO_PROGRESS_MAP[4] = PasswordValidator.prototype.STRENGTH_PROGRESS_4
+
+  /**
+   * Get the CSS class for the meter based on the current level
+   */
+  PasswordValidator.prototype.getStrengthLevelProgressClass = function () {
+    return this.LEVEL_TO_PROGRESS_MAP[this.currentStrengthLevel]
+  }
+
+  PasswordValidator.prototype.addPasswordError = function (error) {
+    if (Array.isArray(error)) {
+      for (var i = 0, ln = error.length; i < ln; i++) {
+        this.addPasswordError(error[i])
+      }
+      return
+    }
+
+    this.errors.push(error)
+  }
+
+  PasswordValidator.prototype.displayPasswordErrors = function () {
+    this.passwordHelpText.innerHTML = '<p>' + this.errors.join('</p><p>') + '</p>'
+  }
+
+  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP = []
+  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[PasswordValidator.prototype.FEEDBACK_SUCCESS] = PasswordValidator.prototype.ICON_SUCCESS
+  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[PasswordValidator.prototype.FEEDBACK_WARNING] = PasswordValidator.prototype.ICON_WARNING
+  PasswordValidator.prototype.FEEDBACK_TO_ICON_MAP[PasswordValidator.prototype.FEEDBACK_ERROR] = PasswordValidator.prototype.ICON_ERROR
+
+  /**
+   * @param success|error|warning feedback
+   */
+  PasswordValidator.prototype.getFeedbackIconClass = function (feedback) {
+    return this.FEEDBACK_TO_ICON_MAP[feedback]
+  }
+
+  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP = []
+  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[PasswordValidator.prototype.FEEDBACK_SUCCESS] = PasswordValidator.prototype.VALIDATION_SUCCESS
+  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[PasswordValidator.prototype.FEEDBACK_WARNING] = PasswordValidator.prototype.VALIDATION_WARNING
+  PasswordValidator.prototype.FEEDBACK_TO_VALIDATION_MAP[PasswordValidator.prototype.FEEDBACK_ERROR] = PasswordValidator.prototype.VALIDATION_ERROR
+
+  /**
+   * @param success|error|warning feedback
+   */
+  PasswordValidator.prototype.getValidationClass = function (feedback) {
+    return this.FEEDBACK_TO_VALIDATION_MAP[feedback]
+  }
+
+  /**
+   * Validators
+   */
+
+  /**
+   * Check if both password fields are equal
+   * @returns {boolean}
+   */
+  PasswordValidator.prototype.checkPasswordFieldsEquality = function () {
+    return this.passwordField.value === this.repeatedPasswordField.value
+  }
+
+  /**
+   * Check if the password is leaked
+   * @param password
+   */
+  PasswordValidator.prototype.checkLeakedPassword = function (password) {
+    var url = 'https://api.pwnedpasswords.com/range/'
+
+    return new Promise(function (resolve, reject) {
+      this.sha1(password).then((digest) => {
+        var preFix = digest.slice(0, 5)
+        var suffix = digest.slice(5, digest.length)
+        suffix = suffix.toUpperCase()
+
+        return fetch(url + preFix)
+          .then(function (response) {
+            return response.text()
+          })
+          .then(function (data) {
+            resolve(data.indexOf(suffix) > -1)
+          })
+          .catch(function (err) {
+            reject(err)
+          })
+      })
+    }.bind(this))
+  }
+
+  PasswordValidator.prototype.handleLeakedPasswordResponse = function (hasPasswordLeaked) {
+    if (hasPasswordLeaked === true) {
+      this.currentStrengthLevel--
+      this.addPasswordError('This password was exposed in a data breach. Please use a more secure alternative one!')
+    }
+
+    this.setPasswordFeedback()
+  }
+
+  /**
+   * CSS Classes reseters
+   */
+
+
+  PasswordValidator.prototype.resetValidation = function (el) {
+    var tokenizedClasses = this.tokenize(
+      this.VALIDATION_ERROR,
+      this.VALIDATION_WARNING,
+      this.VALIDATION_SUCCESS
+    )
+
+    el.classList.remove.apply(
+      el.classList,
+      tokenizedClasses
+    )
+  }
+
+  PasswordValidator.prototype.resetFeedbackIcon = function (el) {
+    var tokenizedClasses = this.tokenize(
+      this.ICON_ERROR,
+      this.ICON_WARNING,
+      this.ICON_SUCCESS
+    )
+
+    el.classList.remove.apply(
+      el.classList,
+      tokenizedClasses
+    )
+  }
+
+  PasswordValidator.prototype.resetStrengthMeter = function () {
+    var tokenizedClasses = this.tokenize(
+      this.STRENGTH_PROGRESS_1,
+      this.STRENGTH_PROGRESS_2,
+      this.STRENGTH_PROGRESS_3,
+      this.STRENGTH_PROGRESS_4
+    )
+
+    this.passwordStrengthMeter.classList.remove.apply(
+      this.passwordStrengthMeter.classList,
+      tokenizedClasses
+    )
+  }
+
+  /**
+   * Helpers
+   */
+
+  PasswordValidator.prototype.getFormGroupElementForField = function (field) {
+    if (field === this.passwordField) {
+      return this.passwordGroup
+    }
+
+    if (field === this.repeatedPasswordField) {
+      return this.repeatedPasswordGroup
+    }
+  }
+
+  PasswordValidator.prototype.getFeedbackElementForField = function (field) {
+    if (field === this.passwordField) {
+      return this.passwordFeedback
+    }
+
+    if (field === this.repeatedPasswordField) {
+      return this.repeatedPasswordFeedback
+    }
+  }
+
+  /**
+   * Returns an array of strings ready to be applied on classList.add or classList.remove
+   * @returns {string[]}
+   */
+  PasswordValidator.prototype.tokenize = function () {
+    var tokenArray = []
+    for (var i in arguments) {
+      tokenArray.push(arguments[i])
+    }
+    return tokenArray.join(' ').split(' ')
+  }
+
+  PasswordValidator.prototype.sha1 = function (str) {
+    let buffer = new TextEncoder('utf-8').encode(str)
+
+    return crypto.subtle.digest('SHA-1', buffer).then(function (hash) {
+      return this.hex(hash)
+    }.bind(this))
+  }
+
+  PasswordValidator.prototype.hex = function (buffer) {
+    let hexCodes = []
+    let view = new DataView(buffer)
+    for (let i = 0; i < view.byteLength; i += 4) {
+      let value = view.getUint32(i)
+      let stringValue = value.toString(16)
+      const padding = '00000000'
+      let paddedValue = (padding + stringValue).slice(-padding.length)
+      hexCodes.push(paddedValue)
+    }
+    return hexCodes.join('')
+  }
+
+  new PasswordValidator(
+    document.getElementById('password'),
+    document.getElementById('repeat_password')
+  )
+})()

--- a/default-templates/new-account/index.html
+++ b/default-templates/new-account/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{#if name}}{{name}} &ndash; {{/if}}Solid Home</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-templates/server/index.html
+++ b/default-templates/server/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Welcome to Solid</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -2,7 +2,7 @@
   <div class="col-md-6">
     <div class="panel panel-default">
       <div class="panel-body">
-        <form method="post" action="/api/accounts/new" onsubmit="return validatePasswordBeforeSubmit(e)">
+        <form method="post" action="/api/accounts/new">
           {{> shared/error}}
 
           <div class="form-group">
@@ -11,16 +11,23 @@
                    required/>
           </div>
 
-          <div class="form-group">
+          <div class="form-group has-feedback">
             <label class="control-label" for="password">Password*</label>
-            <input type="password" class="form-control" name="password" id="password" required/>
-            <div class="checkbox">
-              <label>
-                <input type="checkbox" id="showPassword"/> Show Password
-              </label>
+            <input type="password" class="form-control control-progress" name="password" id="password" required/>
+            <span class="glyphicon glyphicon-remove form-control-feedback hidden" aria-hidden="true"></span>
+            <div class="progress">
+              <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="4"></div>
             </div>
-            <span id="passwordHelp" class="text-danger"></span>
+            <div class="help-block"></div>
           </div>
+
+
+          <div class="form-group has-feedback">
+            <label class="control-label" for="repeat_password">Repeat password*</label>
+            <input type="password" class="form-control" name="repeat_password" id="repeat_password" required/>
+            <span class="glyphicon glyphicon-remove form-control-feedback hidden"></span>
+          </div>
+
 
           <div class="form-group">
             <label class="control-label" for="name">Name*</label>
@@ -37,8 +44,8 @@
             <label class="control-label" for="externalWebId">External WebID:</label>
             <input type="text" class="form-control" name="externalWebId" id="externalWebId"/>
             <span class="help-block">
-                                We will generate a Web ID when you register, but if you already have a Web ID hosted elsewhere that you'd prefer to use to log in, enter it here
-                            </span>
+                We will generate a Web ID when you register, but if you already have a Web ID hosted elsewhere that you'd prefer to use to log in, enter it here
+            </span>
           </div>
 
 
@@ -66,68 +73,6 @@
   </div>
 </div>
 
-
-<script src="/common/js/owasp-password-strength-test.js"
-        defer></script>
-<script>
-    
-</script>
-<script>
-  (function () {
-    'use strict'
-    var showPasswordToggle = document.getElementById('showPassword')
-    var password = document.getElementById('password')
-    showPasswordToggle.addEventListener('change', function () {
-      password.type = password.type === 'password' ? 'text' : 'password'
-    })
-  })()
-
-  function validatePasswordBeforeSubmit (e) {
-        e.preventDefault();
-        const pwdErrorDiv = document.getElementById('passwordHelp');
-        let pw = document.getElementById('password').value;
-        let owaspCheck = owaspPasswordStrengthTest.test(pw)
-        if (owaspCheck.strong === true) {
-            pwdErrorDiv.innerText = '';
-            sha1(pw).then((digest) => {
-              const preFix = digest.slice(0, 5);
-              const url = 'https://api.pwnedpasswords.com/range/';
-              fetch(url+preFix).then(
-                response => response.text()
-              ).then(
-                data => {
-                  if (data.indexOf(digest) !== -1) {
-                      pwdErrorDiv.innerText = 'This password was exposed in a data breach. Please use a more secure alternative one!';
-                      return false;
-                  }
-                }
-              )
-            });
-        }
-        else {
-            pwdErrorDiv.innerText = owaspCheck.requiredTestErrors[0]
-            return false;
-        }
-        return true;
-    }
-
-    function sha1(str) {
-        let buffer = new TextEncoder("utf-8").encode(str);
-        return crypto.subtle.digest("SHA-1", buffer).then(function (hash) {
-            return hex(hash);
-        });
-    }
-
-    function hex(buffer) {
-        let hexCodes = [];
-        let view = new DataView(buffer);
-        for (let i = 0; i < view.byteLength; i += 4) {
-            let value = view.getUint32(i);
-            let stringValue = value.toString(16);
-            const padding = '00000000';
-            let paddedValue = (padding + stringValue).slice(-padding.length);
-            hexCodes.push(paddedValue);
-        }
-        return hexCodes.join("");
-    }
-</script>
+<script src="/common/js/owasp-password-strength-test.js" defer></script>
+<script src="/common/js/text-encoder-lite.min.js" defer></script>
+<script src="/common/js/solid.js" defer></script>

--- a/default-views/account/register.hbs
+++ b/default-views/account/register.hbs
@@ -5,8 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Register</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
-
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/change-password.hbs
+++ b/default-views/auth/change-password.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Change Password</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/consent.hbs
+++ b/default-views/auth/consent.hbs
@@ -6,7 +6,7 @@
   <title>{{title}}</title>
   <!-- Bootstrap CSS and Theme for demo purposes -->
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container title">

--- a/default-views/auth/goodbye.hbs
+++ b/default-views/auth/goodbye.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Logged Out</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/login-required.hbs
+++ b/default-views/auth/login-required.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Log in</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/login.hbs
+++ b/default-views/auth/login.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Login</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/no-permission.hbs
+++ b/default-views/auth/no-permission.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>No permission</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/password-changed.hbs
+++ b/default-views/auth/password-changed.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Password Changed</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/reset-link-sent.hbs
+++ b/default-views/auth/reset-link-sent.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Reset Link Sent</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/default-views/auth/reset-password.hbs
+++ b/default-views/auth/reset-password.hbs
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Reset Password</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/common/css/server.css">
+  <link rel="stylesheet" href="/common/css/solid.css">
 </head>
 <body>
 <div class="container">

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -69,6 +69,8 @@ function createApp (argv = {}) {
 
   // Serve OWASP password checker from it's node_module directory
   routeResolvedFile(app, '/common/js/', 'owasp-password-strength-test/owasp-password-strength-test.js')
+  // Serve the TextEncoder polyfill
+  routeResolvedFile(app, '/common/js/', 'text-encoder-lite/text-encoder-lite.min.js')
 
   // Add CORS proxy
   if (argv.proxy) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8350,6 +8350,11 @@
         "require-main-filename": "^1.0.1"
       }
     },
+    "text-encoder-lite": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/text-encoder-lite/-/text-encoder-lite-1.0.1.tgz",
+      "integrity": "sha512-D+NrUlXDV6Ed9DgYkYqKOsUI/3QSCBzqGooxP2nt27yM7/bxdbEUO7DokP7R8Gwn4r2CNQon3A1Oehw7yAZBzA=="
+    },
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "solid-namespace": "^0.1.0",
     "solid-permissions": "^0.6.0",
     "solid-ws": "^0.2.3",
+    "text-encoder-lite": "^1.0.1",
     "ulid": "^0.1.0",
     "uuid": "^3.0.0",
     "valid-url": "^1.0.9",


### PR DESCRIPTION
This PR is meant to replace #839 which fixes the conflicts created with the merge of #842 and add a password strength meter + repeat password field

Based on the code of @megoth for the second password field and @mintunitish for the password validation functions.

Their code were refactored to have a consistent codebase.

I also had to made a local copy of the owasp-password-strength-test.js because chrome didn't wanted to execute the code since the file is served as 'text/plain'.

I added the glyphicons to be able to show a quick feedback icon on the fields.

I also externalized the JS code in it's own file to be able to compress it if needed later on.
