### PR TITLE
Feature/server-info

### DIFF
--- a/bin/lib/init.js
+++ b/bin/lib/init.js
@@ -31,29 +31,9 @@ module.exports = function (program) {
       // Prompt to the user
       inquirer.prompt(questions)
         .then((answers) => {
-          // setting email
-          if (answers.useEmail) {
-            answers.email = {
-              host: answers['email-host'],
-              port: answers['email-port'],
-              secure: true,
-              auth: {
-                user: answers['email-auth-user'],
-                pass: answers['email-auth-pass']
-              }
-            }
-            delete answers['email-host']
-            delete answers['email-port']
-            delete answers['email-auth-user']
-            delete answers['email-auth-pass']
-          }
-
-          // clean answers
-          Object.keys(answers).forEach((answer) => {
-            if (answer.startsWith('use')) {
-              delete answers[answer]
-            }
-          })
+          manipulateEmailSection(answers)
+          manipulateServerSection(answers)
+          cleanupAnswers(answers)
 
           // write config file
           const config = JSON.stringify(camelize(answers), null, '  ')
@@ -70,4 +50,45 @@ module.exports = function (program) {
           console.log('Error:', err)
         })
     })
+}
+
+function cleanupAnswers (answers) {
+  // clean answers
+  Object.keys(answers).forEach((answer) => {
+    if (answer.startsWith('use')) {
+      delete answers[answer]
+    }
+  })
+}
+
+function manipulateEmailSection (answers) {
+  // setting email
+  if (answers.useEmail) {
+    answers.email = {
+      host: answers['email-host'],
+      port: answers['email-port'],
+      secure: true,
+      auth: {
+        user: answers['email-auth-user'],
+        pass: answers['email-auth-pass']
+      }
+    }
+    delete answers['email-host']
+    delete answers['email-port']
+    delete answers['email-auth-user']
+    delete answers['email-auth-pass']
+  }
+}
+
+function manipulateServerSection (answers) {
+  answers.server = {
+    name: answers['server-name'],
+    description: answers['server-description'],
+    logo: answers['server-logo']
+  }
+  Object.keys(answers).forEach((answer) => {
+    if (answer.startsWith('server-')) {
+      delete answers[answer]
+    }
+  })
 }

--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const validUrl = require('valid-url')
+const { URL } = require('url')
 
 module.exports = [
   // {
@@ -317,6 +318,22 @@ module.exports = [
       }
       return true
     }
+  },
+  {
+    name: 'server-name',
+    help: 'A name for your server (not required, but will be presented on your server\'s frontpage)',
+    prompt: true,
+    default: answers => new URL(answers.serverUri).hostname
+  },
+  {
+    name: 'server-description',
+    help: 'A description of your server (not required)',
+    prompt: true
+  },
+  {
+    name: 'server-logo',
+    help: 'A logo that represents you, your brand or your server (not required)',
+    prompt: true
   }
 ]
 

--- a/bin/lib/options.js
+++ b/bin/lib/options.js
@@ -332,7 +332,7 @@ module.exports = [
   },
   {
     name: 'server-logo',
-    help: 'A logo that represents you, your brand or your server (not required)',
+    help: 'A logo that represents you, your brand, or your server (not required)',
     prompt: true
   }
 ]

--- a/config.json-default
+++ b/config.json-default
@@ -9,5 +9,10 @@
   "sslKey": "./cert.key",
   "sslCert": "./cert.pem",
   "multiuser": true,
-  "corsProxy": "/proxy"
+  "corsProxy": "/proxy",
+  "server": {
+    "name": "",
+    "description": "",
+    "logo": ""
+  }
 }

--- a/default-templates/server/index.html
+++ b/default-templates/server/index.html
@@ -31,6 +31,15 @@
     You are logged in as
     <a href="#" id="profileLink"></a>.
   </p>
+
+
+  <section>
+    <h2>Server info</h2>
+    <dl>
+      <dt>Server name</dt>
+      <dd>{{serverName}}</dd>
+    </dl>
+  </section>
 </div>
 <script src="/common/js/solid-auth-client.bundle.js"></script>
 <script>

--- a/default-templates/server/index.html
+++ b/default-templates/server/index.html
@@ -32,12 +32,20 @@
     <a href="#" id="profileLink"></a>.
   </p>
 
-
   <section>
+    {{#if serverLogo}}
+    <img src="{{serverLogo}}" />
+    {{/if}}
     <h2>Server info</h2>
     <dl>
-      <dt>Server name</dt>
+      <dt>Name</dt>
       <dd>{{serverName}}</dd>
+      {{#if serverDescription}}
+      <dt>Description</dt>
+      <dd>{{serverDescription}}</dd>
+      {{/if}}
+      <dt>Details</dt>
+      <dd>Running on {{serverVersion}} of <a href="https://solid.mit.edu/">Solid</a> (<a href="https://solid.inrupt.com/docs">Documentation</a>)</dd>
     </dl>
   </section>
 </div>

--- a/default-templates/server/index.html
+++ b/default-templates/server/index.html
@@ -45,7 +45,7 @@
       <dd>{{serverDescription}}</dd>
       {{/if}}
       <dt>Details</dt>
-      <dd>Running on {{serverVersion}} of <a href="https://solid.mit.edu/">Solid</a> (<a href="https://solid.inrupt.com/docs">Documentation</a>)</dd>
+      <dd>Running on <a href="https://solid.mit.edu/">Solid {{serverVersion}}</a> (<a href="https://solid.inrupt.com/docs">Documentation</a>)</dd>
     </dl>
   </section>
 </div>

--- a/lib/common/fs-utils.js
+++ b/lib/common/fs-utils.js
@@ -1,0 +1,33 @@
+module.exports.copyTemplateDir = copyTemplateDir
+module.exports.processFile = processFile
+
+const fs = require('fs-extra')
+
+async function copyTemplateDir (templatePath, targetPath) {
+  return new Promise((resolve, reject) => {
+    fs.copy(templatePath, targetPath, (error) => {
+      if (error) { return reject(error) }
+
+      resolve()
+    })
+  })
+}
+
+async function processFile (filePath, manipulateSourceFn) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (error, rawSource) => {
+      if (error) {
+        return reject(error)
+      }
+
+      const output = manipulateSourceFn(rawSource)
+
+      fs.writeFile(filePath, output, (error) => {
+        if (error) {
+          return reject(error)
+        }
+        resolve()
+      })
+    })
+  })
+}

--- a/lib/common/template-utils.js
+++ b/lib/common/template-utils.js
@@ -1,0 +1,38 @@
+module.exports.processHandlebarFile = processHandlebarFile
+
+const Handlebars = require('handlebars')
+const debug = require('../debug').errors
+const { processFile } = require('./fs-utils')
+
+/**
+ * Reads a file, processes it (performing template substitution), and saves
+ * back the processed result.
+ *
+ * @param filePath {string}
+ * @param substitutions {Object}
+ *
+ * @return {Promise}
+ */
+async function processHandlebarFile (filePath, substitutions) {
+  return processFile(filePath, (rawSource) => processHandlebarTemplate(rawSource, substitutions))
+}
+
+/**
+ * Performs a Handlebars string template substitution, and returns the
+ * resulting string.
+ *
+ * @see https://www.npmjs.com/package/handlebars
+ *
+ * @param source {string} e.g. 'Hello, {{name}}'
+ *
+ * @return {string} Result, e.g. 'Hello, Alice'
+ */
+function processHandlebarTemplate (source, substitutions) {
+  try {
+    const template = Handlebars.compile(source)
+    return template(substitutions)
+  } catch (error) {
+    debug(`Error processing template: ${error}`)
+    return source
+  }
+}

--- a/lib/models/account-template.js
+++ b/lib/models/account-template.js
@@ -1,5 +1,7 @@
 'use strict'
 
+import { processHandlebarFile } from '../utils'
+
 const fs = require('fs-extra')
 const path = require('path')
 const mime = require('mime-types')
@@ -130,58 +132,7 @@ class AccountTemplate {
    */
   processAccount (accountPath) {
     return this.readTemplateFiles(accountPath)
-      .then(files => {
-        return Promise.all(
-          files.map((path) => { return this.processFile(path) })
-        )
-      })
-  }
-
-  /**
-   * Reads a file, processes it (performing template substitution), and saves
-   * back the processed result.
-   *
-   * @param filePath {string}
-   *
-   * @return {Promise}
-   */
-  processFile (filePath) {
-    return new Promise((resolve, reject) => {
-      fs.readFile(filePath, 'utf8', (error, rawSource) => {
-        if (error) { return reject(error) }
-
-        let output = this.processTemplate(rawSource)
-
-        fs.writeFile(filePath, output, (error) => {
-          if (error) { return reject(error) }
-          resolve()
-        })
-      })
-    })
-  }
-
-  /**
-   * Performs a Handlebars string template substitution, and returns the
-   * resulting string.
-   *
-   * @see https://www.npmjs.com/package/handlebars
-   *
-   * @param source {string} e.g. 'Hello, {{name}}'
-   *
-   * @return {string} Result, e.g. 'Hello, Alice'
-   */
-  processTemplate (source) {
-    let template, result
-
-    try {
-      template = Handlebars.compile(source)
-      result = template(this.substitutions)
-    } catch (error) {
-      console.log('Error processing template: ', error)
-      return source
-    }
-
-    return result
+      .then(files => Promise.all(files.map(path => processHandlebarFile(path, this.substitutions))))
   }
 
   /**

--- a/lib/models/account-template.js
+++ b/lib/models/account-template.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const fs = require('fs-extra')
 const path = require('path')
 const mime = require('mime-types')
 const recursiveRead = require('recursive-readdir')
-const utils = require('../utils')
+const fsUtils = require('../common/fs-utils')
+const templateUtils = require('../common/template-utils')
 
 const RDF_MIME_TYPES = require('../ldp').RDF_MIME_TYPES
 const TEMPLATE_EXTENSIONS = [ '.acl', '.meta', '.json', '.hbs', '.handlebars' ]
@@ -62,13 +62,7 @@ class AccountTemplate {
    * @return {Promise}
    */
   static copyTemplateDir (templatePath, accountPath) {
-    return new Promise((resolve, reject) => {
-      fs.copy(templatePath, accountPath, (error) => {
-        if (error) { return reject(error) }
-
-        resolve()
-      })
-    })
+    return fsUtils.copyTemplateDir(templatePath, accountPath)
   }
 
   /**
@@ -130,7 +124,7 @@ class AccountTemplate {
    */
   processAccount (accountPath) {
     return this.readTemplateFiles(accountPath)
-      .then(files => Promise.all(files.map(path => utils.processHandlebarFile(path, this.substitutions))))
+      .then(files => Promise.all(files.map(path => templateUtils.processHandlebarFile(path, this.substitutions))))
   }
 
   /**

--- a/lib/models/account-template.js
+++ b/lib/models/account-template.js
@@ -1,12 +1,10 @@
 'use strict'
 
-import { processHandlebarFile } from '../utils'
-
 const fs = require('fs-extra')
 const path = require('path')
 const mime = require('mime-types')
 const recursiveRead = require('recursive-readdir')
-const Handlebars = require('handlebars')
+const utils = require('../utils')
 
 const RDF_MIME_TYPES = require('../ldp').RDF_MIME_TYPES
 const TEMPLATE_EXTENSIONS = [ '.acl', '.meta', '.json', '.hbs', '.handlebars' ]
@@ -132,7 +130,7 @@ class AccountTemplate {
    */
   processAccount (accountPath) {
     return this.readTemplateFiles(accountPath)
-      .then(files => Promise.all(files.map(path => processHandlebarFile(path, this.substitutions))))
+      .then(files => Promise.all(files.map(path => utils.processHandlebarFile(path, this.substitutions))))
   }
 
   /**

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -6,7 +6,8 @@
 
 const fs = require('fs-extra')
 const path = require('path')
-const utils = require('./utils')
+const templateUtils = require('./common/template-utils')
+const fsUtils = require('./common/fs-utils')
 
 /**
  * Ensures that a directory has been copied / initialized. Used to ensure that
@@ -51,8 +52,8 @@ async function ensureWelcomePage (argv) {
   if (!fs.existsSync(existingIndexPage)) {
     console.log(argv)
     fs.mkdirp(serverRootDir)
-    await utils.copyTemplateDir(templates.server, serverRootDir)
-    await utils.processHandlebarFile(existingIndexPage, {
+    await fsUtils.copyTemplateDir(templates.server, serverRootDir)
+    await templateUtils.processHandlebarFile(existingIndexPage, {
       serverName: server ? server.name : host.hostname,
       serverDescription: server ? server.description : '',
       serverLogo: server ? server.logo : '',

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -1,5 +1,4 @@
 'use strict'
-import { processHandlebarFile } from './utils'
 
 /**
  * Server config initialization utilities
@@ -7,6 +6,7 @@ import { processHandlebarFile } from './utils'
 
 const fs = require('fs-extra')
 const path = require('path')
+const utils = require('./utils')
 
 /**
  * Ensures that a directory has been copied / initialized. Used to ensure that
@@ -39,28 +39,23 @@ function ensureDirCopyExists (fromDir, toDir) {
  * @param argv {Function} Express.js app object
  */
 async function ensureWelcomePage (argv) {
-  let { multiuser, templates } = argv
-  let rootDir = path.resolve(argv.root)
-  let serverRootDir
+  const { multiuser, templates } = argv
+  const rootDir = path.resolve(argv.root)
+  const serverRootDir = multiuser ? path.join(rootDir, argv.host.hostname) : rootDir
 
-  if (multiuser) {
-    serverRootDir = path.join(rootDir, argv.host.hostname)
-  } else {
-    serverRootDir = rootDir
-  }
-
-  let defaultIndexPage = path.join(templates.server, 'index.html')
-  let existingIndexPage = path.join(serverRootDir, 'index.html')
-  let defaultIndexPageAcl = path.join(templates.server, 'index.html.acl')
-  let existingIndexPageAcl = path.join(serverRootDir, 'index.html.acl')
+  // let defaultIndexPage = path.join(templates.server, 'index.html')
+  const existingIndexPage = path.join(serverRootDir, 'index.html')
+  // let defaultIndexPageAcl = path.join(templates.server, 'index.html.acl')
+  // let existingIndexPageAcl = path.join(serverRootDir, 'index.html.acl')
 
   if (!fs.existsSync(existingIndexPage)) {
     fs.mkdirp(serverRootDir)
-    fs.copySync(defaultIndexPage, existingIndexPage)
-    await processHandlebarFile(existingIndexPage, {
+    await utils.copyTemplateDir(templates.server, serverRootDir)
+    await utils.processHandlebarFile(existingIndexPage, {
+      serverName: 'Tittentei'
       // Need to load config from somewhere
     })
-    fs.copySync(defaultIndexPageAcl, existingIndexPageAcl)
+    // fs.copySync(defaultIndexPageAcl, existingIndexPageAcl)
   }
 }
 

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -50,7 +50,6 @@ async function ensureWelcomePage (argv) {
   // let existingIndexPageAcl = path.join(serverRootDir, 'index.html.acl')
 
   if (!fs.existsSync(existingIndexPage)) {
-    console.log(argv)
     fs.mkdirp(serverRootDir)
     await fsUtils.copyTemplateDir(templates.server, serverRootDir)
     await templateUtils.processHandlebarFile(existingIndexPage, {

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -36,10 +36,10 @@ function ensureDirCopyExists (fromDir, toDir) {
  * typically has links to account signup and login, and can be overridden by
  * the server operator.
  *
- * @param argv {Function} Express.js app object
+ * @param argv {Object} Express.js app object
  */
 async function ensureWelcomePage (argv) {
-  const { multiuser, templates } = argv
+  const { multiuser, templates, server, host, parent } = argv
   const rootDir = path.resolve(argv.root)
   const serverRootDir = multiuser ? path.join(rootDir, argv.host.hostname) : rootDir
 
@@ -49,11 +49,14 @@ async function ensureWelcomePage (argv) {
   // let existingIndexPageAcl = path.join(serverRootDir, 'index.html.acl')
 
   if (!fs.existsSync(existingIndexPage)) {
+    console.log(argv)
     fs.mkdirp(serverRootDir)
     await utils.copyTemplateDir(templates.server, serverRootDir)
     await utils.processHandlebarFile(existingIndexPage, {
-      serverName: 'Tittentei'
-      // Need to load config from somewhere
+      serverName: server ? server.name : host.hostname,
+      serverDescription: server ? server.description : '',
+      serverLogo: server ? server.logo : '',
+      serverVersion: parent._version
     })
     // fs.copySync(defaultIndexPageAcl, existingIndexPageAcl)
   }

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -40,10 +40,11 @@ function ensureDirCopyExists (fromDir, toDir) {
  * @param argv {Object} Express.js app object
  */
 async function ensureWelcomePage (argv) {
-  const { multiuser, templates, server, host, parent } = argv
+  const { multiuser, templates, server, host } = argv
   const rootDir = path.resolve(argv.root)
   const serverRootDir = multiuser ? path.join(rootDir, argv.host.hostname) : rootDir
   const existingIndexPage = path.join(serverRootDir, 'index.html')
+  const packageData = require('../package.json')
 
   if (!fs.existsSync(existingIndexPage)) {
     fs.mkdirp(serverRootDir)
@@ -52,7 +53,7 @@ async function ensureWelcomePage (argv) {
       serverName: server ? server.name : host.hostname,
       serverDescription: server ? server.description : '',
       serverLogo: server ? server.logo : '',
-      serverVersion: parent._version
+      serverVersion: packageData.version
     })
   }
 }

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -1,4 +1,6 @@
 'use strict'
+import { processHandlebarFile } from './utils'
+
 /**
  * Server config initialization utilities
  */
@@ -36,7 +38,7 @@ function ensureDirCopyExists (fromDir, toDir) {
  *
  * @param argv {Function} Express.js app object
  */
-function ensureWelcomePage (argv) {
+async function ensureWelcomePage (argv) {
   let { multiuser, templates } = argv
   let rootDir = path.resolve(argv.root)
   let serverRootDir
@@ -55,6 +57,9 @@ function ensureWelcomePage (argv) {
   if (!fs.existsSync(existingIndexPage)) {
     fs.mkdirp(serverRootDir)
     fs.copySync(defaultIndexPage, existingIndexPage)
+    await processHandlebarFile(existingIndexPage, {
+      // Need to load config from somewhere
+    })
     fs.copySync(defaultIndexPageAcl, existingIndexPageAcl)
   }
 }

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -43,11 +43,7 @@ async function ensureWelcomePage (argv) {
   const { multiuser, templates, server, host, parent } = argv
   const rootDir = path.resolve(argv.root)
   const serverRootDir = multiuser ? path.join(rootDir, argv.host.hostname) : rootDir
-
-  // let defaultIndexPage = path.join(templates.server, 'index.html')
   const existingIndexPage = path.join(serverRootDir, 'index.html')
-  // let defaultIndexPageAcl = path.join(templates.server, 'index.html.acl')
-  // let existingIndexPageAcl = path.join(serverRootDir, 'index.html.acl')
 
   if (!fs.existsSync(existingIndexPage)) {
     fs.mkdirp(serverRootDir)
@@ -58,7 +54,6 @@ async function ensureWelcomePage (argv) {
       serverLogo: server ? server.logo : '',
       serverVersion: parent._version
     })
-    // fs.copySync(defaultIndexPageAcl, existingIndexPageAcl)
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,6 @@ module.exports.pathBasename = pathBasename
 module.exports.getFullUri = getFullUri
 module.exports.hasSuffix = hasSuffix
 module.exports.parse = parse
-module.exports.processHandlebarFile = processHandlebarFile
 module.exports.serialize = serialize
 module.exports.translate = translate
 module.exports.stringToStream = stringToStream
@@ -14,8 +13,10 @@ module.exports.debrack = debrack
 module.exports.stripLineEndings = stripLineEndings
 module.exports.fullUrlForReq = fullUrlForReq
 module.exports.routeResolvedFile = routeResolvedFile
+module.exports.processHandlebarFile = processHandlebarFile
+module.exports.copyTemplateDir = copyTemplateDir
 
-const fs = require('fs')
+const fs = require('fs-extra')
 const path = require('path')
 const $rdf = require('rdflib')
 const from = require('from2')
@@ -198,9 +199,19 @@ function processHandlebarTemplate (source, substitutions) {
   }
 }
 
+async function copyTemplateDir (templatePath, targetPath) {
+  return new Promise((resolve, reject) => {
+    fs.copy(templatePath, targetPath, (error) => {
+      if (error) { return reject(error) }
+
+      resolve()
+    })
+  })
+}
+
 function serialize (graph, baseUri, contentType, callback) {
   try {
-                // target, kb, base, contentType, callback
+    // target, kb, base, contentType, callback
     $rdf.serialize(null, graph, baseUri, contentType, function (err, result) {
       if (err) {
         console.log(err)
@@ -222,9 +233,9 @@ function serialize (graph, baseUri, contentType, callback) {
 function translate (stream, baseUri, from, to, callback) {
   // Handle Turtle Accept header
   if (to === 'text/turtle' ||
-      to === 'text/n3' ||
-      to === 'application/turtle' ||
-      to === 'application/n3') {
+    to === 'text/n3' ||
+    to === 'application/turtle' ||
+    to === 'application/n3') {
     to = 'text/turtle'
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,16 +13,12 @@ module.exports.debrack = debrack
 module.exports.stripLineEndings = stripLineEndings
 module.exports.fullUrlForReq = fullUrlForReq
 module.exports.routeResolvedFile = routeResolvedFile
-module.exports.processHandlebarFile = processHandlebarFile
-module.exports.copyTemplateDir = copyTemplateDir
 
 const fs = require('fs-extra')
 const path = require('path')
 const $rdf = require('rdflib')
 const from = require('from2')
 const url = require('url')
-const Handlebars = require('handlebars')
-const debug = require('./debug').errors
 
 /**
  * Returns a fully qualified URL from an Express.js Request object.
@@ -149,64 +145,6 @@ function parse (data, baseUri, contentType, callback) {
   } catch (err) {
     return callback(err)
   }
-}
-
-/**
- * Reads a file, processes it (performing template substitution), and saves
- * back the processed result.
- *
- * @param filePath {string}
- * @param substitutions {Object}
- *
- * @return {Promise}
- */
-async function processHandlebarFile (filePath, substitutions) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(filePath, 'utf8', (error, rawSource) => {
-      if (error) {
-        return reject(error)
-      }
-
-      const output = processHandlebarTemplate(rawSource, substitutions)
-
-      fs.writeFile(filePath, output, (error) => {
-        if (error) {
-          return reject(error)
-        }
-        resolve()
-      })
-    })
-  })
-}
-
-/**
- * Performs a Handlebars string template substitution, and returns the
- * resulting string.
- *
- * @see https://www.npmjs.com/package/handlebars
- *
- * @param source {string} e.g. 'Hello, {{name}}'
- *
- * @return {string} Result, e.g. 'Hello, Alice'
- */
-function processHandlebarTemplate (source, substitutions) {
-  try {
-    const template = Handlebars.compile(source)
-    return template(substitutions)
-  } catch (error) {
-    debug(`Error processing template: ${error}`)
-    return source
-  }
-}
-
-async function copyTemplateDir (templatePath, targetPath) {
-  return new Promise((resolve, reject) => {
-    fs.copy(templatePath, targetPath, (error) => {
-      if (error) { return reject(error) }
-
-      resolve()
-    })
-  })
 }
 
 function serialize (graph, baseUri, contentType, callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,6 @@ module.exports.pathBasename = pathBasename
 module.exports.getFullUri = getFullUri
 module.exports.hasSuffix = hasSuffix
 module.exports.parse = parse
-module.exports.processHandlebarFile = processHandlebarFile
 module.exports.serialize = serialize
 module.exports.translate = translate
 module.exports.stringToStream = stringToStream
@@ -14,6 +13,8 @@ module.exports.debrack = debrack
 module.exports.stripLineEndings = stripLineEndings
 module.exports.fullUrlForReq = fullUrlForReq
 module.exports.routeResolvedFile = routeResolvedFile
+module.exports.processHandlebarFile = processHandlebarFile
+module.exports.copyTemplateDir = copyTemplateDir
 
 const fs = require('fs-extra')
 const path = require('path')
@@ -196,6 +197,16 @@ function processHandlebarTemplate (source, substitutions) {
     debug(`Error processing template: ${error}`)
     return source
   }
+}
+
+async function copyTemplateDir (templatePath, targetPath) {
+  return new Promise((resolve, reject) => {
+    fs.copy(templatePath, targetPath, (error) => {
+      if (error) { return reject(error) }
+
+      resolve()
+    })
+  })
 }
 
 function serialize (graph, baseUri, contentType, callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ module.exports.pathBasename = pathBasename
 module.exports.getFullUri = getFullUri
 module.exports.hasSuffix = hasSuffix
 module.exports.parse = parse
+module.exports.processHandlebarFile = processHandlebarFile
 module.exports.serialize = serialize
 module.exports.translate = translate
 module.exports.stringToStream = stringToStream
@@ -19,6 +20,8 @@ const path = require('path')
 const $rdf = require('rdflib')
 const from = require('from2')
 const url = require('url')
+const Handlebars = require('handlebars')
+const debug = require('./debug').errors
 
 /**
  * Returns a fully qualified URL from an Express.js Request object.
@@ -144,6 +147,54 @@ function parse (data, baseUri, contentType, callback) {
     return $rdf.parse(data, graph, baseUri, contentType, callback)
   } catch (err) {
     return callback(err)
+  }
+}
+
+/**
+ * Reads a file, processes it (performing template substitution), and saves
+ * back the processed result.
+ *
+ * @param filePath {string}
+ * @param substitutions {Object}
+ *
+ * @return {Promise}
+ */
+async function processHandlebarFile (filePath, substitutions) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (error, rawSource) => {
+      if (error) {
+        return reject(error)
+      }
+
+      const output = processHandlebarTemplate(rawSource, substitutions)
+
+      fs.writeFile(filePath, output, (error) => {
+        if (error) {
+          return reject(error)
+        }
+        resolve()
+      })
+    })
+  })
+}
+
+/**
+ * Performs a Handlebars string template substitution, and returns the
+ * resulting string.
+ *
+ * @see https://www.npmjs.com/package/handlebars
+ *
+ * @param source {string} e.g. 'Hello, {{name}}'
+ *
+ * @return {string} Result, e.g. 'Hello, Alice'
+ */
+function processHandlebarTemplate (source, substitutions) {
+  try {
+    const template = Handlebars.compile(source)
+    return template(substitutions)
+  } catch (error) {
+    debug(`Error processing template: ${error}`)
+    return source
   }
 }
 

--- a/test/integration/account-creation-oidc-test.js
+++ b/test/integration/account-creation-oidc-test.js
@@ -37,8 +37,8 @@ describe('AccountManager (OIDC account creation tests)', function () {
   after(function () {
     if (ldpHttpsServer) ldpHttpsServer.close()
     fs.removeSync(path.join(dbPath, 'oidc/users/users'))
-    fs.removeSync(path.join(rootPath, 'localhost/index.html'))
-    fs.removeSync(path.join(rootPath, 'localhost/index.html.acl'))
+    fs.removeSync(path.join(rootPath, 'localhost'))
+    fs.removeSync(path.join(rootPath, 'localhost'))
   })
 
   var server = supertest(serverUri)

--- a/test/integration/account-creation-oidc-test.js
+++ b/test/integration/account-creation-oidc-test.js
@@ -2,7 +2,7 @@ const supertest = require('supertest')
 // Helper functions for the FS
 const $rdf = require('rdflib')
 
-const { rm, read, checkDnsSettings } = require('../utils')
+const { rm, read, checkDnsSettings, cleanDir } = require('../utils')
 const ldnode = require('../../index')
 const path = require('path')
 const fs = require('fs-extra')
@@ -37,8 +37,7 @@ describe('AccountManager (OIDC account creation tests)', function () {
   after(function () {
     if (ldpHttpsServer) ldpHttpsServer.close()
     fs.removeSync(path.join(dbPath, 'oidc/users/users'))
-    fs.removeSync(path.join(rootPath, 'localhost'))
-    fs.removeSync(path.join(rootPath, 'localhost'))
+    cleanDir(path.join(rootPath, 'localhost'))
   })
 
   var server = supertest(serverUri)

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -2,7 +2,7 @@ const assert = require('chai').assert
 const fs = require('fs-extra')
 const request = require('request')
 const path = require('path')
-const { loadProvider, rm, checkDnsSettings } = require('../utils')
+const { loadProvider, rm, checkDnsSettings, cleanDir } = require('../utils')
 const IDToken = require('@solid/oidc-op/src/IDToken')
 
 const ldnode = require('../../index')
@@ -86,7 +86,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
 
   after(() => {
     if (ldpHttpsServer) ldpHttpsServer.close()
-    fs.removeSync(path.join(rootPath))
+    cleanDir(rootPath)
   })
 
   const origin1 = 'http://example.org/'

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -86,8 +86,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
 
   after(() => {
     if (ldpHttpsServer) ldpHttpsServer.close()
-    fs.removeSync(path.join(rootPath, 'index.html'))
-    fs.removeSync(path.join(rootPath, 'index.html.acl'))
+    fs.removeSync(path.join(rootPath))
   })
 
   const origin1 = 'http://example.org/'

--- a/test/integration/acl-tls-test.js
+++ b/test/integration/acl-tls-test.js
@@ -69,8 +69,7 @@ describe('ACL with WebID+TLS', function () {
 
   after(function () {
     if (ldpHttpsServer) ldpHttpsServer.close()
-    fs.removeSync(path.join(rootPath, 'index.html'))
-    fs.removeSync(path.join(rootPath, 'index.html.acl'))
+    fs.removeSync(path.join(rootPath))
   })
 
   function createOptions (path, user) {

--- a/test/integration/acl-tls-test.js
+++ b/test/integration/acl-tls-test.js
@@ -3,6 +3,7 @@ var fs = require('fs-extra')
 var $rdf = require('rdflib')
 var request = require('request')
 var path = require('path')
+var { cleanDir } = require('../utils')
 
 /**
  * Note: this test suite requires an internet connection, since it actually
@@ -69,7 +70,7 @@ describe('ACL with WebID+TLS', function () {
 
   after(function () {
     if (ldpHttpsServer) ldpHttpsServer.close()
-    fs.removeSync(path.join(rootPath))
+    cleanDir(rootPath)
   })
 
   function createOptions (path, user) {

--- a/test/integration/auth-proxy-test.js
+++ b/test/integration/auth-proxy-test.js
@@ -3,7 +3,7 @@ const path = require('path')
 const nock = require('nock')
 const request = require('supertest')
 const { expect } = require('chai')
-const rm = require('../utils').rm
+const rmDir = require('../utils').rmDir
 
 const USER = 'https://ruben.verborgh.org/profile/#me'
 
@@ -32,8 +32,7 @@ describe('Auth Proxy', () => {
       // Release back-end server
       nock.cleanAll()
       // Remove created index files
-      rm('index.html')
-      rm('index.html.acl')
+      rmDir()
     })
 
     describe('responding to /server/a', () => {

--- a/test/integration/auth-proxy-test.js
+++ b/test/integration/auth-proxy-test.js
@@ -3,7 +3,7 @@ const path = require('path')
 const nock = require('nock')
 const request = require('supertest')
 const { expect } = require('chai')
-const rmDir = require('../utils').rmDir
+const rm = require('../utils').rm
 
 const USER = 'https://ruben.verborgh.org/profile/#me'
 
@@ -32,7 +32,8 @@ describe('Auth Proxy', () => {
       // Release back-end server
       nock.cleanAll()
       // Remove created index files
-      rmDir()
+      rm('index.html')
+      rm('index.html.acl')
     })
 
     describe('responding to /server/a', () => {

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -10,6 +10,7 @@ const localStorage = require('localstorage-memory')
 const URL = require('whatwg-url').URL
 global.URL = URL
 global.URLSearchParams = require('whatwg-url').URLSearchParams
+const { cleanDir } = require('../utils')
 
 const supertest = require('supertest')
 const chai = require('chai')
@@ -81,8 +82,8 @@ describe('Authentication API (OIDC)', () => {
     alicePod.close()
     bobPod.close()
     fs.removeSync(path.join(aliceDbPath, 'oidc/users'))
-    fs.removeSync(path.join(aliceRootPath))
-    fs.removeSync(path.join(bobRootPath))
+    cleanDir(aliceRootPath)
+    cleanDir(bobRootPath)
   })
 
   describe('Login page (GET /login)', () => {

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -81,10 +81,8 @@ describe('Authentication API (OIDC)', () => {
     alicePod.close()
     bobPod.close()
     fs.removeSync(path.join(aliceDbPath, 'oidc/users'))
-    fs.removeSync(path.join(aliceRootPath, 'index.html'))
-    fs.removeSync(path.join(aliceRootPath, 'index.html.acl'))
-    fs.removeSync(path.join(bobRootPath, 'index.html'))
-    fs.removeSync(path.join(bobRootPath, 'index.html.acl'))
+    fs.removeSync(path.join(aliceRootPath))
+    fs.removeSync(path.join(bobRootPath))
   })
 
   describe('Login page (GET /login)', () => {

--- a/test/integration/capability-discovery-test.js
+++ b/test/integration/capability-discovery-test.js
@@ -1,6 +1,6 @@
 const Solid = require('../../index')
 const path = require('path')
-const fs = require('fs-extra')
+const { cleanDir } = require('../utils')
 const supertest = require('supertest')
 const expect = require('chai').expect
 // In this test we always assume that we are Alice
@@ -48,7 +48,7 @@ describe('API', () => {
 
   after(() => {
     alicePod.close()
-    fs.removeSync(path.join(aliceRootPath))
+    cleanDir(aliceRootPath)
   })
 
   describe('Capability Discovery', () => {

--- a/test/integration/capability-discovery-test.js
+++ b/test/integration/capability-discovery-test.js
@@ -48,8 +48,7 @@ describe('API', () => {
 
   after(() => {
     alicePod.close()
-    fs.removeSync(path.join(aliceRootPath, 'index.html'))
-    fs.removeSync(path.join(aliceRootPath, 'index.html.acl'))
+    fs.removeSync(path.join(aliceRootPath))
   })
 
   describe('Capability Discovery', () => {

--- a/test/integration/errors-oidc-test.js
+++ b/test/integration/errors-oidc-test.js
@@ -1,7 +1,7 @@
 const supertest = require('supertest')
 const ldnode = require('../../index')
 const path = require('path')
-const fs = require('fs-extra')
+const { cleanDir } = require('../utils')
 const expect = require('chai').expect
 
 describe('OIDC error handling', function () {
@@ -30,7 +30,7 @@ describe('OIDC error handling', function () {
 
   after(function () {
     if (ldpHttpsServer) ldpHttpsServer.close()
-    fs.removeSync(path.join(rootPath))
+    cleanDir(rootPath)
   })
 
   const server = supertest(serverUri)

--- a/test/integration/errors-oidc-test.js
+++ b/test/integration/errors-oidc-test.js
@@ -30,8 +30,7 @@ describe('OIDC error handling', function () {
 
   after(function () {
     if (ldpHttpsServer) ldpHttpsServer.close()
-    fs.removeSync(path.join(rootPath, 'index.html'))
-    fs.removeSync(path.join(rootPath, 'index.html.acl'))
+    fs.removeSync(path.join(rootPath))
   })
 
   const server = supertest(serverUri)

--- a/test/integration/params-test.js
+++ b/test/integration/params-test.js
@@ -127,8 +127,7 @@ describe('LDNODE params', function () {
 
     after(function () {
       if (ldpHttpsServer) ldpHttpsServer.close()
-      fs.removeSync(path.join(rootPath, 'index.html'))
-      fs.removeSync(path.join(rootPath, 'index.html.acl'))
+      fs.removeSync(path.join(rootPath))
     })
 
     var server = supertest(serverUri)

--- a/test/integration/params-test.js
+++ b/test/integration/params-test.js
@@ -1,12 +1,8 @@
 var assert = require('chai').assert
 var supertest = require('supertest')
 var path = require('path')
-const fs = require('fs-extra')
 // Helper functions for the FS
-var rm = require('../utils').rm
-var write = require('../utils').write
-// var cp = require('./utils').cp
-var read = require('../utils').read
+const { rm, write, read, cleanDir } = require('../utils')
 
 var ldnode = require('../../index')
 
@@ -127,7 +123,7 @@ describe('LDNODE params', function () {
 
     after(function () {
       if (ldpHttpsServer) ldpHttpsServer.close()
-      fs.removeSync(path.join(rootPath))
+      cleanDir(rootPath)
     })
 
     var server = supertest(serverUri)

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,6 +11,10 @@ exports.rm = function (file) {
   return rimraf.sync(path.join(__dirname, '/resources/' + file))
 }
 
+exports.rmDir = function (path = '') {
+  return rimraf.sync(path.join(__dirname, '/resources/' + path))
+}
+
 exports.write = function (text, file) {
   return fs.writeFileSync(path.join(__dirname, '/resources/' + file), text)
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,4 @@
-var fs = require('fs')
-var fsExtra = require('fs-extra')
+var fs = require('fs-extra')
 var rimraf = require('rimraf')
 var path = require('path')
 const OIDCProvider = require('@solid/oidc-op')
@@ -11,8 +10,14 @@ exports.rm = function (file) {
   return rimraf.sync(path.join(__dirname, '/resources/' + file))
 }
 
-exports.rmDir = function (path = '') {
-  return rimraf.sync(path.join(__dirname, '/resources/' + path))
+exports.cleanDir = function (dirPath) {
+  fs.removeSync(path.join(dirPath, '.well-known/.acl'))
+  fs.removeSync(path.join(dirPath, 'favicon.ico'))
+  fs.removeSync(path.join(dirPath, 'favicon.ico.acl'))
+  fs.removeSync(path.join(dirPath, 'index.html'))
+  fs.removeSync(path.join(dirPath, 'index.html.acl'))
+  fs.removeSync(path.join(dirPath, 'robots.txt'))
+  fs.removeSync(path.join(dirPath, 'robots.txt.acl'))
 }
 
 exports.write = function (text, file) {
@@ -20,7 +25,7 @@ exports.write = function (text, file) {
 }
 
 exports.cp = function (src, dest) {
-  return fsExtra.copySync(
+  return fs.copySync(
     path.join(__dirname, '/resources/' + src),
     path.join(__dirname, '/resources/' + dest))
 }


### PR DESCRIPTION
This PR solves #825 .

- Adds options to init script, that allows those setting up servers to give some human readable info to their visitors
- Makes use of that data to populate a section for the default server index page

In addition:

- It includes a bug fix (didn't copy all of the content in `default-templates/server` to the `data/[server dir]`)
- Some refactoring to reuse existing functionality
- Suggesting where to put util-methods (common methods that are reusable across the system)