### PR TITLE
Update SSL Certificate Naming Convention (Issue 876)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN openssl req \
     -nodes \
     -x509 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" \
-    -keyout cert.key \
-    -out cert.pem
+    -keyout privkey.pem \
+    -out fullchain.pem
 CMD npm run solid start

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -12,11 +12,11 @@ solid can be started on its own by using the solid binary. Below are some exampl
 
 * Starting solid as an HTTPS server with WebID+TLS authentication. This parameter requires that the user specifies the location of the key and the certificate used to start the HTTPS server with the help of the appropriate parameters.
  
- `$ solid --root /var/www --webid --cert ./cert.pem --key ./key.pem`
+ `$ solid --root /var/www --webid --cert ./fullchain.pem --key ./privkey.pem`
 
 * Start HTTPS with custom error pages. solid will look for a file in the specified directory of the form <error-code>.html. If it's not found it will default to node's error page.
 
- `$ solid --root /var/www/ --webid --cert ./cert.pem --key ./key.pem --error-pages ./errors/`
+ `$ solid --root /var/www/ --webid --cert ./fullchain.pem --key ./privkey.pem --error-pages ./errors/`
 
 * solid makes use of special files used for things such as access control, metadata management, subscription to changes, etc. These files are recognized by solid because of their suffix, which can be customized with the command line options that start with 'suffix'.
 
@@ -47,8 +47,3 @@ var existingApp; //Some existing Express app independent of solid.
 var app = solid(options);  
 exisingApp.use('/mount-point', app);  
 ```
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -72,14 +72,17 @@ Solid requires SSL certificates to be valid, so you cannot use self-signed certi
 You need an SSL certificate from a _certificate authority_, such as your domain provider or [Let's Encrypt!](https://letsencrypt.org/getting-started/).
 
 For testing purposes, you can use `bin/solid-test` with a _self-signed_ certificate, generated as follows:
+
 ```
-$ openssl genrsa 2048 > ../localhost.key
-$ openssl req -new -x509 -nodes -sha256 -days 3650 -key ../localhost.key -subj '/CN=*.localhost' > ../localhost.cert
+$ openssl req -outform PEM -keyform PEM -new -x509 -sha256 -newkey rsa:2048 -nodes -keyout ../privkey.pem -days 365 -out ../fullchain.pem
+
 ```
 
-Note that this example creates the `localhost.cert` and `localhost.key` files
+Note that this example creates the `fullchain.pem` and `privkey.pem` files
 in a directory one level higher from the current, so that you don't
 accidentally commit your certificates to `solid` while you're developing.
+
+If you would like to get rid of the browser warnings, import your fullchain.pem certificate into your 'Trusted Root Certificate' store. 
 
 ### Run multi-user server (intermediate)
 

--- a/config.json-default
+++ b/config.json-default
@@ -6,8 +6,8 @@
   "mount": "/",
   "configPath": "./config",
   "dbPath": "./.db",
-  "sslKey": "./cert.key",
-  "sslCert": "./cert.pem",
+  "sslKey": "./privkey.pem",
+  "sslCert": "./fullchain.pem",
   "multiuser": true,
   "corsProxy": "/proxy"
 }


### PR DESCRIPTION
This change addresses Issue #876 'consider renaming localhost.key to privkey.pem'

Edited README.MD
Changed test environment instructions for generating self-signed SSL certificate to explcitly create a PEM certificate.
Added tip to eliminate browser warning.

'./config.json-default' updated
Will now use privkey.pem instead of 'localhost.key' as default SSL private key name in a test environment.

Edited EXAMPLES.MD to reflect preference for new SSL naming convention.

'./config.json-default' updated
Will now use fullchain.pem instead of 'localhost.cert' as default SSL Certificate Name in a test environment.

'./Dockerfile' updated
Will now use fullchain.pem instead of 'localhost.cert' as default SSL Certificate File Name  when generating Certificate Request.

'./Dockerfile' updated
Will now use privkey.pem instead of 'localhost.key' as default SSL Key File Name when generating Certificate Request.

This contribution to Solid is governed by the MIT License.