### PR TITLE
Add private folder to template

### DIFF
--- a/default-templates/new-account/index.html
+++ b/default-templates/new-account/index.html
@@ -42,6 +42,10 @@
         <span class="lead">Public Folder</span>
         <span class="badge">public</span>
       </a>
+      <a href="/private/" target="_blank" class="list-group-item">
+        <span class="lead">Private Folder</span>
+        <span class="badge">private</span>
+      </a>
     </div>
   </section>
 

--- a/default-templates/new-account/private/.acl
+++ b/default-templates/new-account/private/.acl
@@ -1,0 +1,10 @@
+# ACL resource for the private folder
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+
+# The owner has all permissions
+<#owner>
+    a acl:Authorization;
+    acl:agent <{{webId}}>;
+    acl:accessTo <./>;
+    acl:defaultForNew <./>;
+    acl:mode acl:Read, acl:Write, acl:Control.


### PR DESCRIPTION
I watched a new Solid user figure out how to upload stuff to a place no one could see.

Turns out it's hard/unintuitive to create this in the UI:
- creating a child folder of `/` is hard, because there is an HTML page there, not Databrowser;
- when you do create a child folder somewhere else, the "Everyone" icon is listed under Viewers, and I couldn't find how to "drag away" the icon, i.e., not give everyone any permissions.

While this PR doesnm't mitigate the above two issues, at least it provide a private folder by default, which is probably a sensible thing to do.