### PR TITLE
Make --verbose default. Add --silent option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ $ solid start --help
     --server-name [value]         A name for your server (not required, but will be presented on your server's frontpage)
     --server-description [value]  A description of your server (not required)
     --server-logo [value]         A logo that represents you, your brand, or your server (not required)
-    -v, --verbose                 Print the logs to console
+    -s, --silent                  Do not print the logs to console
+    -v, --verbose                 DEPRECATED: Print the logs to console.  
     -h, --help                    output usage information
  ```
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ $ solid start --help
     --server-name [value]         A name for your server (not required, but will be presented on your server's frontpage)
     --server-description [value]  A description of your server (not required)
     --server-logo [value]         A logo that represents you, your brand, or your server (not required)
-    -s, --silent                  Do not print the logs to console
+    -q, --quiet                  Do not print the logs to console
     -v, --verbose                 DEPRECATED: Print the logs to console.  
     -h, --help                    output usage information
  ```

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -32,7 +32,7 @@ module.exports = function (program, server) {
       }
     })
 
-  start.option('-v, --verbose', 'Print the logs to console')
+  start.option('-s, --silent', 'Do not print the logs to console')
 
   start.action((opts) => {
     let argv = extend({}, opts, { version: program.version() })
@@ -76,7 +76,7 @@ function bin (argv, server) {
   argv.live = !argv.noLive
 
   // Set up debug environment
-  if (argv.verbose) {
+  if (!argv.silent) {
     process.env.DEBUG = 'solid:*'
   }
 

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -76,7 +76,7 @@ function bin (argv, server) {
   argv.live = !argv.noLive
 
   // Set up debug environment
-  if (!argv.silent) {
+  if (!argv.quiet) {
     process.env.DEBUG = 'solid:*'
   }
 

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -32,7 +32,7 @@ module.exports = function (program, server) {
       }
     })
 
-  start.option('-s, --silent', 'Do not print the logs to console')
+  start.option('-q, --quiet', 'Do not print the logs to console')
 
   start.action((opts) => {
     let argv = extend({}, opts, { version: program.version() })


### PR DESCRIPTION
Makes verbose the default behavior. Adds a `--silent` option to disable logs. Resolves #906 

