### PR TITLE
Fix failure to log in when requesting binary files

### DIFF
--- a/default-views/auth/login-required.hbs
+++ b/default-views/auth/login-required.hbs
@@ -33,7 +33,7 @@
     const session = await solid.auth.popupLogin()
     if (session) {
       // Make authenticated request to the server to establish a session cookie
-      const {status} = await solid.auth.fetch(location)
+      const {status} = await solid.auth.fetch(location, { method: 'HEAD' })
       if (status === 401) {
         alert(`Invalid login.\n\nDid you set ${session.idp} as your OIDC provider in your profile ${session.webId}?`)
         await solid.auth.logout()


### PR DESCRIPTION
The problem was that the authenticated fetch for establishing
a session cookie was not fully completed when reloading the page.
This caused a new (non-authenticated) session cookie to be created.

This fix changes this fetch request for the session cookie to be a
a header request, so that the request is always finalized
before the reload is called.
An alternative (but less efficient) fix would be to do a regular
request, and consume the whole body before reloading the page.

Closes #878