### PR TITLE
Improvement/invalidusername command

### DIFF
--- a/bin/lib/common.js
+++ b/bin/lib/common.js
@@ -1,17 +1,15 @@
 const fs = require('fs')
 const extend = require('extend')
 const { cyan, bold } = require('colorette')
-const util = require('util')
 
-module.exports = {}
 module.exports.loadConfig = loadConfig
 
-async function loadConfig (program, options) {
+function loadConfig (program, options) {
   let argv = extend({}, options, { version: program.version() })
   let configFile = argv['configFile'] || './config.json'
 
   try {
-    const file = await util.promisify(fs.readFile)(configFile)
+    const file = fs.readFileSync(configFile)
 
     // Use flags with priority over config file
     const config = JSON.parse(file)

--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -35,7 +35,7 @@ module.exports = function (program, server) {
   start.option('-v, --verbose', 'Print the logs to console')
 
   start.action(async (options) => {
-    const config = await loadConfig(program, options)
+    const config = loadConfig(program, options)
     bin(config, server)
   })
 }

--- a/default-views/account/invalid-username.hbs
+++ b/default-views/account/invalid-username.hbs
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Invalid username</title>
   <link rel="stylesheet" href="/common/css/bootstrap.min.css">
-  <script></script>
 </head>
 <body>
 <div class="container">


### PR DESCRIPTION
Some improvement based on comments made in https://github.com/solid/node-solid-server/pull/919. This also contains code that copies `index.html.acl` to `index.backup.html.acl` (and changes file it controls).

@kjetilk Apart from copying the code is the same as earlier, so shouldn't be much need for a thorough review. But if you want to be on the safe side, please assign someone else to review it as well.