### PR TITLE
Fix .well-known/solid/logout not being resolved

### DIFF
--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -82,6 +82,7 @@ function middleware (oidc) {
 
   router.get('/logout', LogoutRequest.handle)
   router.post('/logout', LogoutRequest.handle)
+  router.get('/.well-known/solid/logout/', (req, res) => res.redirect('/logout'))
 
   router.get('/goodbye', (req, res) => { res.render('auth/goodbye') })
 


### PR DESCRIPTION
As far as I can see, no route for `.well-known/solid/logout` has been configured, so let's add one.