### PR TITLE
A simple node-script equivalent for solid-test

### DIFF
--- a/bin/solid-test.js
+++ b/bin/solid-test.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
+
+const startCli = require('./lib/cli')
+startCli()


### PR DESCRIPTION
I'm uncertain how smart setting a variable for process.env is, but this works for me. Hopefully someone with more Node experience than me can verify if it's smart or not.

(I use [nodemon](https://www.npmjs.com/package/nodemon) when developing, to enable a quick restart when I change code, so I find this script useful)