### PR TITLE
Remove old /logout bindings - PR v2

### DIFF
--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -80,8 +80,6 @@ function middleware (oidc) {
   router.get('/account/password/change', PasswordChangeRequest.get)
   router.post('/account/password/change', bodyParser, PasswordChangeRequest.post)
 
-  router.get('/logout', LogoutRequest.handle)
-  router.post('/logout', LogoutRequest.handle)
   router.get('/.well-known/solid/logout/', (req, res) => res.redirect('/logout'))
 
   router.get('/goodbye', (req, res) => { res.render('auth/goodbye') })

--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -12,10 +12,7 @@ const { LoginRequest } = require('../../requests/login-request')
 const PasswordResetEmailRequest = require('../../requests/password-reset-email-request')
 const PasswordChangeRequest = require('../../requests/password-change-request')
 
-const {
-  AuthCallbackRequest,
-  LogoutRequest
-} = require('@solid/oidc-auth-manager').handlers
+const { AuthCallbackRequest } = require('@solid/oidc-auth-manager').handlers
 
 /**
  * Sets up OIDC authentication for the given app.


### PR DESCRIPTION
Replaces https://github.com/solid/node-solid-server/pull/857

This patch is the original patch https://github.com/solid/node-solid-server/pull/857/commits/834aebedfd6a4299e520bd490d6db520196e7c4a for https://github.com/solid/node-solid-server/pull/857 recreated on top of release/v5.0.0 with a prior merge conflict resolved.