### PR TITLE
Fix index path creation on Windows

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -4,6 +4,7 @@ const path = require('path')
 const debug = require('debug')('solid:index')
 const utils = require('../utils')
 const Negotiator = require('negotiator')
+const url = require('url')
 
 function handler (req, res, next) {
   const indexFile = 'index.html'
@@ -33,7 +34,7 @@ function handler (req, res, next) {
       if (err) {
         return next()
       }
-      res.locals.path = path.join(req.path, indexFile)
+      res.locals.path = url.resolve(req.path, indexFile)
       debug('Found an index for current path')
       return next()
     })


### PR DESCRIPTION
path.join created a backslash on Windows, causing the resulting URL in the end to be incorrect. This change uses the url library instead to construct the path.