### PR TITLE
Make migration tool also scan through config/templates

### DIFF
--- a/bin/lib/migrateLegacyResources.js
+++ b/bin/lib/migrateLegacyResources.js
@@ -20,13 +20,15 @@ module.exports = function (program) {
     .action(async (opts) => {
       const verbose = opts.verbose
       const suffix = opts.suffix || '$.ttl'
-      let path = opts.path || 'data'
-      path = path.startsWith(Path.sep) ? path : Path.join(process.cwd(), path)
-      if (verbose) {
-        console.log(`Migrating files in ${path}`)
-      }
+      let paths = opts.path ? [ opts.path ] : [ 'data', 'config/templates' ]
+      paths = paths.map(path => path.startsWith(Path.sep) ? path : Path.join(process.cwd(), path))
       try {
-        await migrate(path, suffix, verbose)
+        for (const path of paths) {
+          if (verbose) {
+            console.log(`Migrating files in ${path}`)
+          }
+          await migrate(path, suffix, verbose)
+        }
       } catch (err) {
         console.error(err)
       }


### PR DESCRIPTION
This makes it so that `solid migrate-legacy-resources` will migrate both `data/` _and_ `config/templates`. The latter is needed because `config/templates/new-account/profile/card` is also applicable to these new changes.