### PR TITLE
Fix no logging output appearing when in non-quiet-mode

### DIFF
--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -62,7 +62,7 @@ function bin (argv, server) {
 
   // Set up debug environment
   if (!argv.quiet) {
-    process.env.DEBUG = 'solid:*'
+    require('debug').enable('solid:*')
   }
 
   // Set up port


### PR DESCRIPTION
This was because the logging level was set via an environment variable
*after* the debugger was already constructed.

Closes #979