### PR TITLE
Fix registration from solid-auth-client not redirecting after login

### DIFF
--- a/lib/requests/create-account-request.js
+++ b/lib/requests/create-account-request.js
@@ -307,8 +307,7 @@ class CreateOidcAccountRequest extends CreateAccountRequest {
   }
 
   sendResponse (userAccount) {
-    let redirectUrl = this.returnToUrl ||
-      this.accountManager.accountUriFor(userAccount.username)
+    let redirectUrl = this.returnToUrl || this.loginUrl()
     this.response.redirect(redirectUrl)
 
     return userAccount


### PR DESCRIPTION
This is fixed by redirecting directly to the loginUrl after registration,
which includes the original query parameters,
and includes the original (encoded) redirect URL.

Closes solid/solid-auth-client#98