### PR TITLE
Hide register button when logged in

### DIFF
--- a/common/js/auth-buttons.js
+++ b/common/js/auth-buttons.js
@@ -15,6 +15,7 @@
     const isOwner = loggedIn && new URL(session.webId).origin === location.origin
     loginButton.classList.toggle('hidden', loggedIn)
     logoutButton.classList.toggle('hidden', !loggedIn)
+    registerButton.classList.toggle('hidden', loggedIn)
     accountSettings.classList.toggle('hidden', !isOwner)
   })
 


### PR DESCRIPTION
The register button is not needed anymore when the user has been logged in, so let's hide it in that case.