### PR TITLE
Fix account settings always being hidden

### DIFF
--- a/common/js/auth-buttons.js
+++ b/common/js/auth-buttons.js
@@ -3,7 +3,7 @@
 (({ auth }) => {
   // Wire up DOM elements
   const [loginButton, logoutButton, registerButton, accountSettings] =
-    ['login', 'logout', 'register', 'accountSettings'].map(id =>
+    ['login', 'logout', 'register', 'account-settings'].map(id =>
       document.getElementById(id) || document.createElement('a'))
   loginButton.addEventListener('click', login)
   logoutButton.addEventListener('click', logout)


### PR DESCRIPTION
The wrong account settings class name was being used, so account settings were always hidden.