### PR TITLE
Add logout button to login-required view

### DIFF
--- a/default-views/auth/login-required.hbs
+++ b/default-views/auth/login-required.hbs
@@ -13,6 +13,7 @@
     <div class="pull-right">
       <button id="register" type="button" class="btn btn-primary">Register</button>
       <button id="login"    type="button" class="btn btn-success">Log in</button>
+      <button id="logout"   type="button" class="hidden btn btn-danger">Log out</button>
     </div>
     <h1>Log in to access this resource</h1>
   </div>


### PR DESCRIPTION
This is needed because a server may invalidate the user's session,
without the client-side code knowing of this.
In this case, the user should be allowed to log out its (invalid)
session, and login again to get a new session.

This is a proposed fix for #1004.
Ideally, the user should be logged out automatically,
but as this is not a trivial thing to solve properly,
this fix is a good alternative for now.