### PR TITLE
Add server origin by default to the list of trusted origins

### DIFF
--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -50,7 +50,7 @@ function allow (mode) {
       },
       suffix: ldp.suffixAcl,
       strictOrigin: ldp.strictOrigin,
-      trustedOrigins: ldp.trustedOrigins
+      trustedOrigins: [ldp.resourceMapper.resolveUrl(req.hostname)].concat(ldp.trustedOrigins)
     })
 
     // Ensure the user has the required permission

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -212,13 +212,31 @@ describe('Authentication API (OIDC)', () => {
           })
         })
 
-        // Our origin isn't trusted by default
+        // Our origin is trusted by default
         describe('with that cookie and our origin', () => {
           let response
           before(done => {
             alice.get('/')
               .set('Cookie', cookie)
               .set('Origin', aliceServerUri)
+              .end((err, res) => {
+                response = res
+                done(err)
+              })
+          })
+
+          it('should return a 200', () => {
+            expect(response).to.have.property('status', 200)
+          })
+        })
+
+        // Another origin isn't trusted by default
+        describe('with that cookie and our origin', () => {
+          let response
+          before(done => {
+            alice.get('/')
+              .set('Cookie', cookie)
+              .set('Origin', 'https://some.other.domain.com')
               .end((err, res) => {
                 response = res
                 done(err)


### PR DESCRIPTION
This fixed #994, and updates the unit tests to correspond to the change.