### PR TITLE
Fix server printing stacktrace after logging in, Closes #1000

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -74,8 +74,7 @@ async function handler (req, res, next) {
   if (!includeBody) {
     debug('HEAD only')
     res.setHeader('Content-Type', ret.contentType)
-    res.status(200).send('OK')
-    return next()
+    return res.status(200).send('OK')
   }
 
   // Handle dataBrowser


### PR DESCRIPTION
This was because header.js tried to add headers after the response was already sent.