### PR TITLE
Make DELETE require write permissions on container

### DIFF
--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { promisify } = require('util')
 const HTTPError = require('../http-error')
 
-function allow (mode, relativePath = '') {
+function allow (mode, testDirectory) {
   return async function allowHandler (req, res, next) {
     const ldp = req.app.locals.ldp || {}
     if (!ldp.webid) {
@@ -25,8 +25,8 @@ function allow (mode, relativePath = '') {
       : req.path
 
     // If a relativePath has been provided, check permissions based on that
-    if (relativePath) {
-      reqPath = path.join(reqPath, relativePath)
+    if (testDirectory) {
+      reqPath = path.dirname(reqPath)
     }
 
     // Check whether the resource exists

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { promisify } = require('util')
 const HTTPError = require('../http-error')
 
-function allow (mode, testDirectory) {
+function allow (mode, checkPermissionsForDirectory) {
   return async function allowHandler (req, res, next) {
     const ldp = req.app.locals.ldp || {}
     if (!ldp.webid) {
@@ -20,31 +20,31 @@ function allow (mode, testDirectory) {
 
     // Determine the actual path of the request
     // (This is used as an ugly hack to check the ACL status of other resources.)
-    let reqPath = res && res.locals && res.locals.path
+    let resourcePath = res && res.locals && res.locals.path
       ? res.locals.path
       : req.path
 
-    // If a relativePath has been provided, check permissions based on that
-    if (testDirectory) {
-      reqPath = path.dirname(reqPath)
+    // Check permissions of the directory instead of the file itself.
+    if (checkPermissionsForDirectory) {
+      resourcePath = path.dirname(resourcePath)
     }
 
     // Check whether the resource exists
     let stat
     try {
-      const ret = await ldp.exists(req.hostname, reqPath)
+      const ret = await ldp.exists(req.hostname, resourcePath)
       stat = ret.stream
     } catch (err) {
       stat = null
     }
 
     // Ensure directories always end in a slash
-    if (!reqPath.endsWith('/') && stat && stat.isDirectory()) {
-      reqPath += '/'
+    if (!resourcePath.endsWith('/') && stat && stat.isDirectory()) {
+      resourcePath += '/'
     }
 
     // Obtain and store the ACL of the requested resource
-    req.acl = new ACL(rootUrl + reqPath, {
+    req.acl = new ACL(rootUrl + resourcePath, {
       agentOrigin: req.get('origin'),
       // host: req.get('host'),
       fetch: fetchFromLdp(ldp.resourceMapper),

--- a/lib/handlers/allow.js
+++ b/lib/handlers/allow.js
@@ -1,13 +1,14 @@
 module.exports = allow
 
 const $rdf = require('rdflib')
+const path = require('path')
 const ACL = require('../acl-checker')
 const debug = require('../debug.js').ACL
 const fs = require('fs')
 const { promisify } = require('util')
 const HTTPError = require('../http-error')
 
-function allow (mode) {
+function allow (mode, relativePath = '') {
   return async function allowHandler (req, res, next) {
     const ldp = req.app.locals.ldp || {}
     if (!ldp.webid) {
@@ -22,6 +23,11 @@ function allow (mode) {
     let reqPath = res && res.locals && res.locals.path
       ? res.locals.path
       : req.path
+
+    // If a relativePath has been provided, check permissions based on that
+    if (relativePath) {
+      reqPath = path.join(reqPath, relativePath)
+    }
 
     // Check whether the resource exists
     let stat

--- a/lib/ldp-middleware.js
+++ b/lib/ldp-middleware.js
@@ -26,7 +26,7 @@ function LdpMiddleware (corsSettings) {
   router.post('/*', allow('Append'), post)
   router.patch('/*', allow('Append'), patch)
   router.put('/*', allow('Write'), put)
-  router.delete('/*', allow('Write'), del)
+  router.delete('/*', allow('Write', '..'), del)
 
   return router
 }

--- a/lib/ldp-middleware.js
+++ b/lib/ldp-middleware.js
@@ -26,7 +26,7 @@ function LdpMiddleware (corsSettings) {
   router.post('/*', allow('Append'), post)
   router.patch('/*', allow('Append'), patch)
   router.put('/*', allow('Write'), put)
-  router.delete('/*', allow('Write', '..'), del)
+  router.delete('/*', allow('Write', true), del)
 
   return router
 }


### PR DESCRIPTION
DELETE will now basically always check the permissions of the parent directory.

As requested in #729.