### PR TITLE
Use http schema for solid terms

### DIFF
--- a/default-templates/new-account/settings/privateTypeIndex.ttl
+++ b/default-templates/new-account/settings/privateTypeIndex.ttl
@@ -1,4 +1,4 @@
-@prefix solid: <https://www.w3.org/ns/solid/terms#>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
 <>
     a solid:TypeIndex ;
     a solid:UnlistedDocument.

--- a/default-templates/new-account/settings/publicTypeIndex.ttl
+++ b/default-templates/new-account/settings/publicTypeIndex.ttl
@@ -1,4 +1,4 @@
-@prefix solid: <https://www.w3.org/ns/solid/terms#>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
 <>
     a solid:TypeIndex ;
     a solid:ListedDocument.

--- a/test/resources/accounts-acl/config/templates/new-account/settings/privateTypeIndex.ttl
+++ b/test/resources/accounts-acl/config/templates/new-account/settings/privateTypeIndex.ttl
@@ -1,4 +1,4 @@
-@prefix solid: <https://www.w3.org/ns/solid/terms#>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
 <>
     a solid:TypeIndex ;
     a solid:UnlistedDocument.

--- a/test/resources/accounts-acl/config/templates/new-account/settings/publicTypeIndex.ttl
+++ b/test/resources/accounts-acl/config/templates/new-account/settings/publicTypeIndex.ttl
@@ -1,4 +1,4 @@
-@prefix solid: <https://www.w3.org/ns/solid/terms#>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
 <>
     a solid:TypeIndex ;
     a solid:ListedDocument.


### PR DESCRIPTION
Should fix #1002. 

Done against 5.0.0, can be cherry-picked to 4.4 if needed.