### PR TITLE
Fix path-related Windows problems

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -5,6 +5,7 @@ const debug = require('debug')('solid:index')
 const utils = require('../utils')
 const Negotiator = require('negotiator')
 const url = require('url')
+const URI = require('urijs')
 
 function handler (req, res, next) {
   const indexFile = 'index.html'
@@ -21,7 +22,7 @@ function handler (req, res, next) {
     }
     // redirect to the right container if missing trailing /
     if (req.path.lastIndexOf('/') !== req.path.length - 1) {
-      return res.redirect(301, path.join(req.path, '/'))
+      return res.redirect(301, URI.joinPaths(req.path, '/', '//').toString())
     }
 
     if (requestedType && requestedType.indexOf('text/html') !== 0) {

--- a/lib/header.js
+++ b/lib/header.js
@@ -53,7 +53,7 @@ function linksHandler (req, res, next) {
     return next(error(404, 'Trying to access metadata file as regular file'))
   }
   let fileMetadata = new metadata.Metadata()
-  if (filename.endsWith('/')) {
+  if (req.path.endsWith('/')) {
     fileMetadata.isContainer = true
     fileMetadata.isBasicContainer = true
   } else {

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -17,6 +17,7 @@ const ldpContainer = require('./ldp-container')
 const parse = require('./utils').parse
 const fetch = require('node-fetch')
 const { promisify } = require('util')
+const URI = require('urijs')
 
 const DEFAULT_CONTENT_TYPE = 'text/turtle'
 
@@ -263,7 +264,7 @@ class LDP {
     const filePath = utils.uriToFilename(resourcePath, root, host)
 
     // PUT requests not supported on containers. Use POST instead
-    if (filePath.endsWith('/')) {
+    if (resourcePath.endsWith('/')) {
       return callback(error(409,
         'PUT not supported on containers, use POST instead'))
     }
@@ -420,6 +421,11 @@ class LDP {
         return callback(error(err, 'Can\'t find file requested: ' + filename))
       }
 
+      // windows does not differentiate between file paths with or without trailing slash
+      if (reqPath.substr(-1) === '/' && !stats.isDirectory()) {
+        return callback(error(404, 'Can\'t find directory requested: ' + filename))
+      }
+
       // Just return, since resource exists
       if (!includeBody) {
         return callback(null, {'stream': stats, 'contentType': contentType, 'container': stats.isDirectory()})
@@ -540,13 +546,13 @@ class LDP {
       // Verify whether the new path already exists
       return self.exists(host, newPath).then(
         // If it does, generate another one
-        () => ensureNotExists(self, path.join(containerURI,
-                `${uuid.v1().split('-')[0]}-${filename}`)),
+        () => ensureNotExists(self, URI.joinPaths(containerURI,
+                `${uuid.v1().split('-')[0]}-${filename}`).toString()),
         // If not, we found an appropriate path
         () => newPath
       )
     }
-    return ensureNotExists(this, path.join(containerURI, filename))
+    return ensureNotExists(this, URI.joinPaths(containerURI, filename).toString())
   }
 }
 module.exports = LDP

--- a/lib/resource-mapper.js
+++ b/lib/resource-mapper.js
@@ -58,7 +58,8 @@ class ResourceMapper {
   // Maps a given server file to a URL
   async mapFileToUrl ({ path, hostname }) {
     // Determine the URL by chopping off everything after the dollar sign
-    const pathname = this._removeDollarExtension(path.substring(this._rootPath.length))
+    let pathname = this._removeDollarExtension(path.substring(this._rootPath.length))
+    pathname = this._replaceBackslashes(pathname)
     const url = `${this.getBaseUrl(hostname)}${encodeURI(pathname)}`
     return { url, contentType: this._getContentTypeByExtension(path) }
   }
@@ -100,6 +101,10 @@ class ResourceMapper {
   _removeDollarExtension (path) {
     const dollarPos = path.lastIndexOf('$')
     return dollarPos < 0 ? path : path.substr(0, dollarPos)
+  }
+
+  _replaceBackslashes (path) {
+    return path.replace(/\\/g, '/')
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -89,9 +89,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "js-tokens": {
@@ -106,7 +106,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2152,6 +2152,29 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -4176,6 +4199,12 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -4973,6 +5002,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
     "nock": {
@@ -6539,6 +6574,12 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
@@ -7280,6 +7321,21 @@
         "sha.js": "~2.4.4"
       }
     },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "shell-quote": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
@@ -7523,7 +7579,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -7532,9 +7588,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cli-cursor": {
@@ -7543,7 +7599,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "debug": {
@@ -7561,9 +7617,9 @@
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
-            "chardet": "0.4.2",
-            "iconv-lite": "0.4.24",
-            "tmp": "0.0.33"
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
           }
         },
         "figures": {
@@ -7572,7 +7628,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "inquirer": {
@@ -7581,20 +7637,20 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.2.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.11",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -7621,7 +7677,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -7630,8 +7686,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "string-width": {
@@ -7640,8 +7696,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -7650,7 +7706,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -7659,7 +7715,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "tmp": {
@@ -7668,7 +7724,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         }
       }
@@ -7745,7 +7801,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         }
       }
@@ -7926,7 +7982,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         }
       }
@@ -8114,7 +8170,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -9120,6 +9176,11 @@
         }
       }
     },
+    "urijs": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -9257,6 +9318,15 @@
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "win-release": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "text-encoder-lite": "^1.0.1",
     "the-big-username-blacklist": "^1.5.1",
     "ulid": "^0.1.0",
+    "urijs": "^1.19.1",
     "uuid": "^3.0.0",
     "valid-url": "^1.0.9",
     "validator": "^10.9.0",
@@ -92,6 +93,7 @@
     "@solid/solid-auth-oidc": "^0.3.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "cross-env": "^5.2.0",
     "dirty-chai": "^1.2.2",
     "localstorage-memory": "^1.0.2",
     "mocha": "^5.1.1",
@@ -110,8 +112,8 @@
   "scripts": {
     "solid": "node ./bin/solid",
     "standard": "standard '{bin,examples,lib,test}/**/*.js'",
-    "nyc": "NODE_TLS_REJECT_UNAUTHORIZED=0 nyc --reporter=text-summary mocha",
-    "mocha": "NODE_TLS_REJECT_UNAUTHORIZED=0 mocha",
+    "nyc": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 nyc --reporter=text-summary mocha",
+    "mocha": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 mocha",
     "test": "npm run standard && npm run nyc",
     "clean": "rimraf config/templates config/views"
   },

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -575,9 +575,9 @@ describe('HTTP APIs', function () {
         .expect(getResourceName)
         .end(done)
     })
-    it('should be able to delete newly created resource', function (done) {
+    it('should be able to delete newly created resource (2)', function (done) {
       server.delete('/' +
-          postedResourceName.replace(/https?:\/\/127.0.0.1:[0-9]*\//, ''))
+          postedResourceName.replace(/https?:\/\/((127.0.0.1)|(localhost)):[0-9]*\//, ''))
         .expect(200, done)
     })
     it('should create container', function (done) {

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -1,6 +1,7 @@
 var assert = require('chai').assert
 
 var utils = require('../../lib/utils')
+var path = require('path')
 
 describe('Utility functions', function () {
   describe('pathBasename', function () {
@@ -23,13 +24,13 @@ describe('Utility functions', function () {
 
   describe('uriToFilename', function () {
     it('should decode hex-encoded space', function () {
-      assert.equal(utils.uriToFilename('uri%20', 'base/'), 'base/uri ')
+      assert.equal(utils.uriToFilename('uri%20', 'base/'), path.join('base', 'uri '))
     })
     it('should decode hex-encoded at sign', function () {
-      assert.equal(utils.uriToFilename('film%4011', 'base/'), 'base/film@11')
+      assert.equal(utils.uriToFilename('film%4011', 'base/'), path.join('base', 'film@11'))
     })
     it('should decode hex-encoded single quote', function () {
-      assert.equal(utils.uriToFilename('quote%27', 'base/'), 'base/quote\'')
+      assert.equal(utils.uriToFilename('quote%27', 'base/'), path.join('base', 'quote\''))
     })
   })
 


### PR DESCRIPTION
This makes sure all unit tests pass on Windows. A new library was added to combine URI paths (these could be relative URLs) since url.resolve doesn't always have the required behaviour.

I tried to update Travis to also build on Windows, but there are still several problems there that I didn't manage to resolve yet (the host settings were ignored and symlink support requires additional git config settings before cloning)