### PR TITLE
Add npm script for solid-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
   "main": "index.js",
   "scripts": {
     "solid": "node ./bin/solid",
+    "solid-test": "./bin/solid-test",
     "standard": "standard '{bin,examples,lib,test}/**/*.js'",
     "nyc": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 nyc --reporter=text-summary mocha",
     "mocha": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 mocha",


### PR DESCRIPTION
Adds an npm script for `solid-test` so it has a similar workflow to `solid`.