### PR TITLE
Serves statusMessage based on what response acl-check gives

### DIFF
--- a/lib/acl-checker.js
+++ b/lib/acl-checker.js
@@ -58,11 +58,13 @@ class ACLChecker {
     const trustedOrigins = this.trustedOrigins ? this.trustedOrigins.map(trustedOrigin => rdf.sym(trustedOrigin)) : null
     const accessDenied = aclCheck.accessDenied(acl.graph, resource, directory, aclFile, agent, modes, agentOrigin, trustedOrigins)
     if (accessDenied && this.agentOrigin && this.resourceUrl.origin !== this.agentOrigin) {
-      this.messagesCached[cacheKey].push(new HTTPError(403, accessDenied))
+      this.messagesCached[cacheKey].push(HTTPError(403, accessDenied))
     } else if (accessDenied && user) {
-      this.messagesCached[cacheKey].push(new HTTPError(403, accessDenied))
+      this.messagesCached[cacheKey].push(HTTPError(403, accessDenied))
+    } else if (accessDenied && !user) {
+      this.messagesCached[cacheKey].push(HTTPError(401, 'Unauthenticated'))
     } else if (accessDenied) {
-      this.messagesCached[cacheKey].push(new HTTPError(401, accessDenied))
+      this.messagesCached[cacheKey].push(HTTPError(401, accessDenied))
     }
     this.aclCached[cacheKey] = Promise.resolve(!accessDenied)
     return this.aclCached[cacheKey]

--- a/lib/handlers/error-pages.js
+++ b/lib/handlers/error-pages.js
@@ -32,7 +32,7 @@ function handler (err, req, res, next) {
       renderLoginRequired(req, res, err)
       break
     case 403:
-      renderNoPermission(req, res)
+      renderNoPermission(req, res, err)
       break
     default:
       if (ldp.noErrorPages) {
@@ -131,10 +131,10 @@ function sendErrorPage (statusCode, res, err, ldp) {
  * @param req {IncomingRequest}
  * @param res {ServerResponse}
  */
-function renderLoginRequired (req, res, error) {
+function renderLoginRequired (req, res, err) {
   const currentUrl = util.fullUrlForReq(req)
   debug(`Display login-required for ${currentUrl}`)
-  res.statusMessage = error.statusText
+  res.statusMessage = err.message
   res.status(401)
   res.render('auth/login-required', { currentUrl })
 }
@@ -145,10 +145,11 @@ function renderLoginRequired (req, res, error) {
  * @param req {IncomingRequest}
  * @param res {ServerResponse}
  */
-function renderNoPermission (req, res) {
+function renderNoPermission (req, res, err) {
   const currentUrl = util.fullUrlForReq(req)
   const webId = req.session.userId
   debug(`Display no-permission for ${currentUrl}`)
+  res.statusMessage = err.message
   res.status(403)
   res.render('auth/no-permission', { currentUrl, webId })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,9 +202,9 @@
       }
     },
     "@solid/acl-check": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@solid/acl-check/-/acl-check-0.1.2.tgz",
-      "integrity": "sha512-1e9/HAyRARpVUXpAGtNILF+mnCdIljkbAoLjRrgI1jb5CEMEdsP94iu4ADlC+aoIZob6hsDpoo975oB2nMqqew==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@solid/acl-check/-/acl-check-0.1.3.tgz",
+      "integrity": "sha512-Rvdxn7SOlqo1BtiY6dcFlJAjne0QK1hrsFL1q3HUDg7yleOEXBm1ESyZ0XDM6jwqJHqKf+0l987D15k5MPyIng==",
       "requires": {
         "rdflib": "^0.12.1",
         "solid-namespace": "0.1.0"
@@ -212,7 +212,7 @@
       "dependencies": {
         "rdflib": {
           "version": "0.12.3",
-          "resolved": "http://registry.npmjs.org/rdflib/-/rdflib-0.12.3.tgz",
+          "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-0.12.3.tgz",
           "integrity": "sha1-K0IGamYJwGtAqQSFhJNix8uV6h4=",
           "requires": {
             "async": "^0.9.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,7 +212,7 @@
       "dependencies": {
         "rdflib": {
           "version": "0.12.3",
-          "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-0.12.3.tgz",
+          "resolved": "http://registry.npmjs.org/rdflib/-/rdflib-0.12.3.tgz",
           "integrity": "sha1-K0IGamYJwGtAqQSFhJNix8uV6h4=",
           "requires": {
             "async": "^0.9.x",
@@ -1604,7 +1604,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1628,7 +1628,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -2052,7 +2052,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2194,7 +2194,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -2206,7 +2206,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -2472,7 +2472,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -2494,7 +2494,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -2602,7 +2602,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3455,7 +3455,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3577,7 +3577,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3861,7 +3861,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -4237,7 +4237,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4414,7 +4414,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
@@ -4923,7 +4923,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -4990,7 +4990,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6539,7 +6539,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -6644,7 +6644,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
         "asn1.js": "^4.0.0",
@@ -6869,7 +6869,7 @@
     },
     "proxy-agent": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
       "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
       "dev": true,
       "requires": {
@@ -7042,7 +7042,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7412,7 +7412,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -7733,7 +7733,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -8495,7 +8495,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8533,7 +8533,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8574,7 +8574,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8612,7 +8612,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8730,7 +8730,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -8910,7 +8910,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -9435,7 +9435,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "bugs": "https://github.com/solid/node-solid-server/issues",
   "dependencies": {
     "@solid/oidc-auth-manager": "^0.17.1",
-    "@solid/acl-check": "^0.1.2",
+    "@solid/acl-check": "^0.1.3",
     "body-parser": "^1.18.3",
     "bootstrap": "^3.3.7",
     "busboy": "^0.2.12",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "name": "Kjetil Kjernsmo",
       "email": "kjetil@inrupt.com",
       "url": "http://kjetil.kjernsmo.net/"
+    },
+    {
+      "name": "Arne Hassel",
+      "email": "arne.hassel@inrupt.com",
+      "url": "https://icanhasweb.net/"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,6 @@
       "name": "Kjetil Kjernsmo",
       "email": "kjetil@inrupt.com",
       "url": "http://kjetil.kjernsmo.net/"
-    },
-    {
-      "name": "Arne Hassel",
-      "email": "arne.hassel@inrupt.com",
-      "url": "https://icanhasweb.net/"
     }
   ],
   "license": "MIT",

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -271,7 +271,13 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
         ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n' +
+        '<#Somebody> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agent> <' + user2 + '>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#default> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Write> .\n'
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 201)
@@ -290,6 +296,16 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
+    it('user2 should be able to access public test directory with wrong origin', function (done) {
+      var options = createOptions('/origin/test-folder/', 'user2')
+      options.headers.origin = origin2
+
+      request.head(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 200)
+        done()
+      })
+    })
     it('user1 should be able to access to test directory when origin is valid',
       function (done) {
         var options = createOptions('/origin/test-folder/', 'user1')
@@ -301,15 +317,14 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
-    it('user1 should not be able to access test directory when origin is invalid',
+    it('user1 should be able to access public test directory even when origin is invalid',
       function (done) {
         var options = createOptions('/origin/test-folder/', 'user1')
         options.headers.origin = origin2
 
         request.head(options, function (error, response, body) {
           assert.equal(error, null)
-          assert.equal(response.statusCode, 403)
-          assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
+          assert.equal(response.statusCode, 200)
           done()
         })
       })
@@ -334,21 +349,43 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
-    it('agent should not be able to access test directory when origin is invalid',
+    it('agent should be able to access public test directory even when origin is invalid',
       function (done) {
         var options = createOptions('/origin/test-folder/')
         options.headers.origin = origin2
 
         request.head(options, function (error, response, body) {
           assert.equal(error, null)
-          assert.equal(response.statusCode, 403)
-          assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
+          assert.equal(response.statusCode, 200)
           done()
         })
       })
+    it('user2 should be able to write to test directory with correct origin', function (done) {
+      var options = createOptions('/origin/test-folder/test1.txt', 'user2', 'text/plain')
+      options.headers.origin = origin1
+      options.body = 'DAAAAAHUUUT'
+      request.put(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 201)
+        done()
+      })
+    })
+    it('user2 should not be able to write to test directory with wrong origin', function (done) {
+      var options = createOptions('/origin/test-folder/test2.txt', 'user2', 'text/plain')
+      options.headers.origin = origin2
+      options.body = 'ARRRRGH'
+      request.put(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 403)
+        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
+        done()
+      })
+    })
 
     after(function () {
       rm('/accounts-acl/tim.localhost/origin/test-folder/.acl')
+      rm('/accounts-acl/tim.localhost/origin/test-folder/test1.txt')
+      rm('/accounts-acl/tim.localhost/origin/test-folder/test2.txt')
     })
   })
 

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -301,27 +301,24 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it('user1 should be able to access to test directory when origin is valid',
-      function (done) {
-        var options = createOptions('/origin/test-folder/', 'user1')
-        options.headers.origin = origin1
+    it('user1 should be able to access to test directory when origin is valid', function (done) {
+      var options = createOptions('/origin/test-folder/', 'user1')
+      options.headers.origin = origin1
 
-        request.head(options, function (error, response, body) {
-          assert.equal(error, null)
-          assert.equal(response.statusCode, 200)
-          done()
-        })
+      request.head(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 200)
+        done()
       })
-    it('user1 should be able to access public test directory even when origin is invalid',
-      function (done) {
-        var options = createOptions('/origin/test-folder/', 'user1')
-        options.headers.origin = origin2
+    })
+    it('user1 should be able to access public test directory even when origin is invalid', function (done) {
+      var options = createOptions('/origin/test-folder/', 'user1')
+      options.headers.origin = origin2
 
-        request.head(options, function (error, response, body) {
-          assert.equal(error, null)
-          assert.equal(response.statusCode, 200)
-          done()
-        })
+      request.head(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 200)
+        done()
       })
     })
     it('agent should be able to access test directory', function (done) {
@@ -343,8 +340,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         assert.equal(response.statusCode, 200)
         done()
       })
-    it('agent should be able to access public test directory even when origin is invalid',
-      function (done) {
+      it('agent should be able to access public test directory even when origin is invalid', function (done) {
         var options = createOptions('/origin/test-folder/')
         options.headers.origin = origin2
 
@@ -354,532 +350,533 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
-    it('user2 should be able to write to test directory with correct origin', function (done) {
-      var options = createOptions('/origin/test-folder/test1.txt', 'user2', 'text/plain')
-      options.headers.origin = origin1
-      options.body = 'DAAAAAHUUUT'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
+      it('user2 should be able to write to test directory with correct origin', function (done) {
+        var options = createOptions('/origin/test-folder/test1.txt', 'user2', 'text/plain')
+        options.headers.origin = origin1
+        options.body = 'DAAAAAHUUUT'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
       })
-    })
-    it('user2 should not be able to write to test directory with wrong origin', function (done) {
-      var options = createOptions('/origin/test-folder/test2.txt', 'user2', 'text/plain')
-      options.headers.origin = origin2
-      options.body = 'ARRRRGH'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
-        done()
+      it('user2 should not be able to write to test directory with wrong origin', function (done) {
+        var options = createOptions('/origin/test-folder/test2.txt', 'user2', 'text/plain')
+        options.headers.origin = origin2
+        options.body = 'ARRRRGH'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
+          done()
+        })
+      })
+
+      after(function () {
+        rm('/accounts-acl/tim.localhost/origin/test-folder/.acl')
+        rm('/accounts-acl/tim.localhost/origin/test-folder/test1.txt')
+        rm('/accounts-acl/tim.localhost/origin/test-folder/test2.txt')
       })
     })
 
-    after(function () {
-      rm('/accounts-acl/tim.localhost/origin/test-folder/.acl')
-      rm('/accounts-acl/tim.localhost/origin/test-folder/test1.txt')
-      rm('/accounts-acl/tim.localhost/origin/test-folder/test2.txt')
-    })
-  })
-
-  describe('Read-only', function () {
-    var body = fs.readFileSync(path.join(rootPath, 'tim.localhost/read-acl/.acl'))
-    it('user1 should be able to access ACL file', function (done) {
-      var options = createOptions('/read-acl/.acl', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+    describe('Read-only', function () {
+      var body = fs.readFileSync(path.join(rootPath, 'tim.localhost/read-acl/.acl'))
+      it('user1 should be able to access ACL file', function (done) {
+        var options = createOptions('/read-acl/.acl', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it('user1 should be able to access test directory', function (done) {
-      var options = createOptions('/read-acl/', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      it('user1 should be able to access test directory', function (done) {
+        var options = createOptions('/read-acl/', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it('user1 should be able to modify ACL file', function (done) {
-      var options = createOptions('/read-acl/.acl', 'user1', 'text/turtle')
-      options.body = body
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
+      it('user1 should be able to modify ACL file', function (done) {
+        var options = createOptions('/read-acl/.acl', 'user1', 'text/turtle')
+        options.body = body
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
       })
-    })
-    it('user2 should be able to access test directory', function (done) {
-      var options = createOptions('/read-acl/', 'user2')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      it('user2 should be able to access test directory', function (done) {
+        var options = createOptions('/read-acl/', 'user2')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it('user2 should not be able to access ACL file', function (done) {
-      var options = createOptions('/read-acl/.acl', 'user2')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
+      it('user2 should not be able to access ACL file', function (done) {
+        var options = createOptions('/read-acl/.acl', 'user2')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
       })
-    })
-    it('user2 should not be able to modify ACL file', function (done) {
-      var options = createOptions('/read-acl/.acl', 'user2', 'text/turtle')
-      options.body = '<d> <e> <f> .'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
+      it('user2 should not be able to modify ACL file', function (done) {
+        var options = createOptions('/read-acl/.acl', 'user2', 'text/turtle')
+        options.body = '<d> <e> <f> .'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
       })
-    })
-    it('agent should be able to access test direcotory', function (done) {
-      var options = createOptions('/read-acl/')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      it('agent should be able to access test direcotory', function (done) {
+        var options = createOptions('/read-acl/')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it('agent should not be able to modify ACL file', function (done) {
-      var options = createOptions('/read-acl/.acl', null, 'text/turtle')
-      options.body = '<d> <e> <f> .'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthenticated')
-        done()
+      it('agent should not be able to modify ACL file', function (done) {
+        var options = createOptions('/read-acl/.acl', null, 'text/turtle')
+        options.body = '<d> <e> <f> .'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 401)
+          assert.equal(response.statusMessage, 'Unauthenticated')
+          done()
+        })
       })
-    })
-    // Deep acl:accessTo inheritance is not supported yet #963
-    it.skip('user1 should be able to access deep test directory ACL', function (done) {
-      var options = createOptions('/read-acl/deeper-tree/.acl', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      // Deep acl:accessTo inheritance is not supported yet #963
+      it.skip('user1 should be able to access deep test directory ACL', function (done) {
+        var options = createOptions('/read-acl/deeper-tree/.acl', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it.skip('user1 should not be able to access deep test dir', function (done) {
-      var options = createOptions('/read-acl/deeper-tree/', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
+      it.skip('user1 should not be able to access deep test dir', function (done) {
+        var options = createOptions('/read-acl/deeper-tree/', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
       })
-    })
-    it.skip('user1 should able to access even deeper test directory', function (done) {
-      var options = createOptions('/read-acl/deeper-tree/acls-only-on-top/', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      it.skip('user1 should able to access even deeper test directory', function (done) {
+        var options = createOptions('/read-acl/deeper-tree/acls-only-on-top/', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it.skip('user1 should able to access even deeper test file', function (done) {
-      var options = createOptions('/read-acl/deeper-tree/acls-only-on-top/example.ttl', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-  })
-
-  describe('Append-only', function () {
-    // var body = fs.readFileSync(__dirname + '/resources/append-acl/abc.ttl.acl')
-    it('user1 should be able to access test file\'s ACL file', function (done) {
-      var options = createOptions('/append-acl/abc.ttl.acl', 'user1')
-      request.head(options, function (error, response) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it.skip('user1 should be able to PATCH a resource', function (done) {
-      var options = createOptions('/append-inherited/test.ttl', 'user1')
-      options.body = 'INSERT DATA { :test  :hello 456 .}'
-      options.headers['content-type'] = 'application/sparql-update'
-      request.patch(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('user1 should be able to PATCH an existing resource', function (done) {
-      var options = createOptions('/append-inherited/test.ttl', 'user1')
-      options.body = 'INSERT DATA { :test  :hello 789 .}'
-      options.headers['content-type'] = 'application/sparql-update'
-      request.patch(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('user1 should be able to access test file', function (done) {
-      var options = createOptions('/append-acl/abc.ttl', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    // TODO POST instead of PUT
-    it('user1 should be able to modify test file', function (done) {
-      var options = createOptions('/append-acl/abc.ttl', 'user1', 'text/turtle')
-      options.body = '<a> <b> <c> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
-      })
-    })
-    it('user2 should not be able to access test file\'s ACL file', function (done) {
-      var options = createOptions('/append-acl/abc.ttl.acl', 'user2', 'text/turtle')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
-      })
-    })
-    it('user2 should not be able to access test file', function (done) {
-      var options = createOptions('/append-acl/abc.ttl', 'user2', 'text/turtle')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
-      })
-    })
-    it('user2 (with append permission) cannot use PUT to append', function (done) {
-      var options = createOptions('/append-acl/abc.ttl', 'user2', 'text/turtle')
-      options.body = '<d> <e> <f> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
-      })
-    })
-    it('agent should not be able to access test file', function (done) {
-      var options = createOptions('/append-acl/abc.ttl')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthenticated')
-        done()
-      })
-    })
-    it('agent (with append permissions) should not PUT', function (done) {
-      var options = createOptions('/append-acl/abc.ttl', null, 'text/turtle')
-      options.body = '<g> <h> <i> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthenticated')
-        done()
-      })
-    })
-    after(function () {
-      rm('/accounts-acl/tim.localhost/append-inherited/test.ttl')
-    })
-  })
-
-  describe('Group', function () {
-    // before(function () {
-    //   rm('/accounts-acl/tim.localhost/group/test-folder/.acl')
-    // })
-
-    // it('should PUT new ACL file', function (done) {
-    //   var options = createOptions('/group/test-folder/.acl', 'user1')
-    //   options.body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-    //     ' <http://www.w3.org/ns/auth/acl#accessTo> <./.acl>;\n' +
-    //     ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
-    //     ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
-    //     '<#Public> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-    //     ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
-    //     ' <http://www.w3.org/ns/auth/acl#agentGroup> <group-listing#folks>;\n' +
-    //     ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
-    //   request.put(options, function (error, response, body) {
-    //     assert.equal(error, null)
-    //     assert.equal(response.statusCode, 201)
-    //     done()
-    //   })
-    // })
-    it('user1 should be able to access test directory', function (done) {
-      var options = createOptions('/group/test-folder/', 'user1')
-
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('user2 should be able to access test directory', function (done) {
-      var options = createOptions('/group/test-folder/', 'user2')
-
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('user2 should be able to write a file in the test directory', function (done) {
-      var options = createOptions('/group/test-folder/test.ttl', 'user2', 'text/turtle')
-      options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
-
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
+      it.skip('user1 should able to access even deeper test file', function (done) {
+        var options = createOptions('/read-acl/deeper-tree/acls-only-on-top/example.ttl', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
     })
 
-    it('user1 should be able to get the file', function (done) {
-      var options = createOptions('/group/test-folder/test.ttl', 'user1', 'text/turtle')
-
-      request.get(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+    describe('Append-only', function () {
+      // var body = fs.readFileSync(__dirname + '/resources/append-acl/abc.ttl.acl')
+      it('user1 should be able to access test file\'s ACL file', function (done) {
+        var options = createOptions('/append-acl/abc.ttl.acl', 'user1')
+        request.head(options, function (error, response) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it('user2 should not be able to write to the ACL', function (done) {
-      var options = createOptions('/group/test-folder/.acl', 'user2', 'text/turtle')
-      options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
-
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
+      it.skip('user1 should be able to PATCH a resource', function (done) {
+        var options = createOptions('/append-inherited/test.ttl', 'user1')
+        options.body = 'INSERT DATA { :test  :hello 456 .}'
+        options.headers['content-type'] = 'application/sparql-update'
+        request.patch(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-
-    it('user1 should be able to delete the file', function (done) {
-      var options = createOptions('/group/test-folder/test.ttl', 'user1', 'text/turtle')
-
-      request.delete(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200) // Should be 204, right?
-        done()
+      it('user1 should be able to PATCH an existing resource', function (done) {
+        var options = createOptions('/append-inherited/test.ttl', 'user1')
+        options.body = 'INSERT DATA { :test  :hello 789 .}'
+        options.headers['content-type'] = 'application/sparql-update'
+        request.patch(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it('We should have a 500 with invalid group listings', function (done) {
-      var options = createOptions('/group/test-folder/some-other-file.txt', 'user2')
-
-      request.get(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 500)
-        done()
+      it('user1 should be able to access test file', function (done) {
+        var options = createOptions('/append-acl/abc.ttl', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
       })
-    })
-    it('We should have a 404 for non-existent file', function (done) {
-      var options = createOptions('/group/test-folder/nothere.txt', 'user2')
-
-      request.get(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 404)
-        done()
+      // TODO POST instead of PUT
+      it('user1 should be able to modify test file', function (done) {
+        var options = createOptions('/append-acl/abc.ttl', 'user1', 'text/turtle')
+        options.body = '<a> <b> <c> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
       })
-    })
-  })
-
-  describe('Restricted', function () {
-    var body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#accessTo> <./abc2.ttl>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
-      '<#Restricted> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#accessTo> <./abc2.ttl>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#agent> <' + user2 + '>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>.\n'
-    it('user1 should be able to modify test file\'s ACL file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl.acl', 'user1', 'text/turtle')
-      options.body = body
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
+      it('user2 should not be able to access test file\'s ACL file', function (done) {
+        var options = createOptions('/append-acl/abc.ttl.acl', 'user2', 'text/turtle')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
       })
-    })
-    it('user1 should be able to access test file\'s ACL file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl.acl', 'user1', 'text/turtle')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      it('user2 should not be able to access test file', function (done) {
+        var options = createOptions('/append-acl/abc.ttl', 'user2', 'text/turtle')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
       })
-    })
-    it('user1 should be able to access test file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl', 'user1', 'text/turtle')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      it('user2 (with append permission) cannot use PUT to append', function (done) {
+        var options = createOptions('/append-acl/abc.ttl', 'user2', 'text/turtle')
+        options.body = '<d> <e> <f> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
       })
-    })
-    it('user1 should be able to modify test file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl', 'user1', 'text/turtle')
-      options.body = '<a> <b> <c> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
+      it('agent should not be able to access test file', function (done) {
+        var options = createOptions('/append-acl/abc.ttl')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 401)
+          assert.equal(response.statusMessage, 'Unauthenticated')
+          done()
+        })
       })
-    })
-    it('user2 should be able to access test file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl', 'user2')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
+      it('agent (with append permissions) should not PUT', function (done) {
+        var options = createOptions('/append-acl/abc.ttl', null, 'text/turtle')
+        options.body = '<g> <h> <i> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 401)
+          assert.equal(response.statusMessage, 'Unauthenticated')
+          done()
+        })
       })
-    })
-    it('user2 should not be able to access test file\'s ACL file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl.acl', 'user2')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
-      })
-    })
-    it('user2 should be able to modify test file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl', 'user2', 'text/turtle')
-      options.body = '<d> <e> <f> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
-      })
-    })
-    it('agent should not be able to access test file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthenticated')
-        done()
-      })
-    })
-    it('agent should not be able to modify test file', function (done) {
-      var options = createOptions('/append-acl/abc2.ttl', null, 'text/turtle')
-      options.body = '<d> <e> <f> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthenticated')
-        done()
-      })
-    })
-  })
-
-  describe('default', function () {
-    before(function () {
-      rm('/accounts-acl/tim.localhost/write-acl/default-for-new/.acl')
-      rm('/accounts-acl/tim.localhost/write-acl/default-for-new/test-file.ttl')
-    })
-
-    var body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#default> <./>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
-      '<#Default> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#default> <./>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
-      ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
-    it('user1 should be able to modify test directory\'s ACL file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/.acl', 'user1', 'text/turtle')
-      options.body = body
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
-      })
-    })
-    it('user1 should be able to access test direcotory\'s ACL file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/.acl', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('user1 should be able to create new test file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user1', 'text/turtle')
-      options.body = '<a> <b> <c> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 201)
-        done()
-      })
-    })
-    it('user1 should be able to access new test file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user1')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('user2 should not be able to access test direcotory\'s ACL file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/.acl', 'user2')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
-      })
-    })
-    it('user2 should be able to access new test file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user2')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('user2 should not be able to modify new test file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user2', 'text/turtle')
-      options.body = '<d> <e> <f> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'User Unauthorized')
-        done()
-      })
-    })
-    it('agent should be able to access new test file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/test-file.ttl')
-      request.head(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
-        done()
-      })
-    })
-    it('agent should not be able to modify new test file', function (done) {
-      var options = createOptions('/write-acl/default-for-new/test-file.ttl', null, 'text/turtle')
-      options.body = '<d> <e> <f> .\n'
-      request.put(options, function (error, response, body) {
-        assert.equal(error, null)
-        assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthenticated')
-        done()
+      after(function () {
+        rm('/accounts-acl/tim.localhost/append-inherited/test.ttl')
       })
     })
 
-    after(function () {
-      rm('/accounts-acl/tim.localhost/write-acl/default-for-new/.acl')
-      rm('/accounts-acl/tim.localhost/write-acl/default-for-new/test-file.ttl')
+    describe('Group', function () {
+      // before(function () {
+      //   rm('/accounts-acl/tim.localhost/group/test-folder/.acl')
+      // })
+
+      // it('should PUT new ACL file', function (done) {
+      //   var options = createOptions('/group/test-folder/.acl', 'user1')
+      //   options.body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+      //     ' <http://www.w3.org/ns/auth/acl#accessTo> <./.acl>;\n' +
+      //     ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
+      //     ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
+      //     '<#Public> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+      //     ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
+      //     ' <http://www.w3.org/ns/auth/acl#agentGroup> <group-listing#folks>;\n' +
+      //     ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
+      //   request.put(options, function (error, response, body) {
+      //     assert.equal(error, null)
+      //     assert.equal(response.statusCode, 201)
+      //     done()
+      //   })
+      // })
+      it('user1 should be able to access test directory', function (done) {
+        var options = createOptions('/group/test-folder/', 'user1')
+
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user2 should be able to access test directory', function (done) {
+        var options = createOptions('/group/test-folder/', 'user2')
+
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user2 should be able to write a file in the test directory', function (done) {
+        var options = createOptions('/group/test-folder/test.ttl', 'user2', 'text/turtle')
+        options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
+
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
+      })
+
+      it('user1 should be able to get the file', function (done) {
+        var options = createOptions('/group/test-folder/test.ttl', 'user1', 'text/turtle')
+
+        request.get(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user2 should not be able to write to the ACL', function (done) {
+        var options = createOptions('/group/test-folder/.acl', 'user2', 'text/turtle')
+        options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
+
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
+      })
+
+      it('user1 should be able to delete the file', function (done) {
+        var options = createOptions('/group/test-folder/test.ttl', 'user1', 'text/turtle')
+
+        request.delete(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200) // Should be 204, right?
+          done()
+        })
+      })
+      it('We should have a 500 with invalid group listings', function (done) {
+        var options = createOptions('/group/test-folder/some-other-file.txt', 'user2')
+
+        request.get(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 500)
+          done()
+        })
+      })
+      it('We should have a 404 for non-existent file', function (done) {
+        var options = createOptions('/group/test-folder/nothere.txt', 'user2')
+
+        request.get(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 404)
+          done()
+        })
+      })
+    })
+
+    describe('Restricted', function () {
+      var body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <./abc2.ttl>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
+        '<#Restricted> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <./abc2.ttl>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agent> <' + user2 + '>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>.\n'
+      it('user1 should be able to modify test file\'s ACL file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl.acl', 'user1', 'text/turtle')
+        options.body = body
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
+      })
+      it('user1 should be able to access test file\'s ACL file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl.acl', 'user1', 'text/turtle')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user1 should be able to access test file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl', 'user1', 'text/turtle')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user1 should be able to modify test file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl', 'user1', 'text/turtle')
+        options.body = '<a> <b> <c> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
+      })
+      it('user2 should be able to access test file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl', 'user2')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user2 should not be able to access test file\'s ACL file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl.acl', 'user2')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
+      })
+      it('user2 should be able to modify test file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl', 'user2', 'text/turtle')
+        options.body = '<d> <e> <f> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
+      })
+      it('agent should not be able to access test file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 401)
+          assert.equal(response.statusMessage, 'Unauthenticated')
+          done()
+        })
+      })
+      it('agent should not be able to modify test file', function (done) {
+        var options = createOptions('/append-acl/abc2.ttl', null, 'text/turtle')
+        options.body = '<d> <e> <f> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 401)
+          assert.equal(response.statusMessage, 'Unauthenticated')
+          done()
+        })
+      })
+    })
+
+    describe('default', function () {
+      before(function () {
+        rm('/accounts-acl/tim.localhost/write-acl/default-for-new/.acl')
+        rm('/accounts-acl/tim.localhost/write-acl/default-for-new/test-file.ttl')
+      })
+
+      var body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#default> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
+        '<#Default> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#default> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
+      it('user1 should be able to modify test directory\'s ACL file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/.acl', 'user1', 'text/turtle')
+        options.body = body
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
+      })
+      it('user1 should be able to access test direcotory\'s ACL file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/.acl', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user1 should be able to create new test file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user1', 'text/turtle')
+        options.body = '<a> <b> <c> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 201)
+          done()
+        })
+      })
+      it('user1 should be able to access new test file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user1')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user2 should not be able to access test direcotory\'s ACL file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/.acl', 'user2')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
+      })
+      it('user2 should be able to access new test file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user2')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('user2 should not be able to modify new test file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/test-file.ttl', 'user2', 'text/turtle')
+        options.body = '<d> <e> <f> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 403)
+          assert.equal(response.statusMessage, 'User Unauthorized')
+          done()
+        })
+      })
+      it('agent should be able to access new test file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/test-file.ttl')
+        request.head(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 200)
+          done()
+        })
+      })
+      it('agent should not be able to modify new test file', function (done) {
+        var options = createOptions('/write-acl/default-for-new/test-file.ttl', null, 'text/turtle')
+        options.body = '<d> <e> <f> .\n'
+        request.put(options, function (error, response, body) {
+          assert.equal(error, null)
+          assert.equal(response.statusCode, 401)
+          assert.equal(response.statusMessage, 'Unauthenticated')
+          done()
+        })
+      })
+
+      after(function () {
+        rm('/accounts-acl/tim.localhost/write-acl/default-for-new/.acl')
+        rm('/accounts-acl/tim.localhost/write-acl/default-for-new/test-file.ttl')
+      })
     })
   })
 })

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -2,7 +2,7 @@ const assert = require('chai').assert
 const fs = require('fs-extra')
 const request = require('request')
 const path = require('path')
-const { loadProvider, rm, checkDnsSettings, cleanDir } = require('../utils')
+const {loadProvider, rm, checkDnsSettings, cleanDir} = require('../utils')
 const IDToken = require('@solid/oidc-op/src/IDToken')
 
 const ldnode = require('../../index')
@@ -30,16 +30,15 @@ let userCredentials = {
 }
 
 function issueIdToken (oidcProvider, webId) {
-  return Promise.resolve()
-    .then(() => {
-      let jwt = IDToken.issue(oidcProvider, {
-        sub: webId,
-        aud: [ serverUri, 'client123' ],
-        azp: 'client123'
-      })
-
-      return jwt.encode()
+  return Promise.resolve().then(() => {
+    let jwt = IDToken.issue(oidcProvider, {
+      sub: webId,
+      aud: [serverUri, 'client123'],
+      azp: 'client123'
     })
+
+    return jwt.encode()
+  })
 }
 
 const argv = {
@@ -54,7 +53,7 @@ const argv = {
   multiuser: true,
   auth: 'oidc',
   strictOrigin: true,
-  host: { serverUri }
+  host: {serverUri}
 }
 
 describe('ACL with WebID+OIDC over HTTP', function () {
@@ -65,23 +64,19 @@ describe('ACL with WebID+OIDC over HTTP', function () {
   before(done => {
     ldp = ldnode.createServer(argv)
 
-    loadProvider(oidcProviderPath)
-      .then(provider => {
-        oidcProvider = provider
+    loadProvider(oidcProviderPath).then(provider => {
+      oidcProvider = provider
 
-        return Promise.all([
-          issueIdToken(oidcProvider, user1),
-          issueIdToken(oidcProvider, user2)
-        ])
-      })
-      .then(tokens => {
-        userCredentials.user1 = tokens[0]
-        userCredentials.user2 = tokens[1]
-      })
-      .then(() => {
-        ldpHttpsServer = ldp.listen(port, done)
-      })
-      .catch(console.error)
+      return Promise.all([
+        issueIdToken(oidcProvider, user1),
+        issueIdToken(oidcProvider, user2)
+      ])
+    }).then(tokens => {
+      userCredentials.user1 = tokens[0]
+      userCredentials.user2 = tokens[1]
+    }).then(() => {
+      ldpHttpsServer = ldp.listen(port, done)
+    }).catch(console.error)
   })
 
   after(() => {
@@ -227,7 +222,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
-      it("should create test file's acl file", function (done) {
+      it('should create test file\'s acl file', function (done) {
         var options = createOptions('/write-acl/test-file.acl', 'user1', 'text/turtle')
         options.body = ''
         request.put(options, function (error, response, body) {
@@ -236,7 +231,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
-      it("should not access test file's new empty acl file", function (done) {
+      it('should not access test file\'s new empty acl file', function (done) {
         var options = createOptions('/write-acl/test-file.acl', 'user1')
         request.get(options, function (error, response, body) {
           assert.equal(error, null)
@@ -282,8 +277,8 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         assert.equal(error, null)
         assert.equal(response.statusCode, 201)
         done()
-      // TODO triple header
-      // TODO user header
+        // TODO triple header
+        // TODO user header
       })
     })
     it('user1 should be able to access test directory', function (done) {
@@ -328,6 +323,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
+    })
     it('agent should be able to access test directory', function (done) {
       var options = createOptions('/origin/test-folder/')
       options.headers.origin = origin1
@@ -338,16 +334,14 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it('agent should be able to access to test directory when origin is valid',
-      function (done) {
-        var options = createOptions('/origin/test-folder/', 'user1')
-        options.headers.origin = origin1
+    it('agent should be able to access to test directory when origin is valid', function (done) {
+      var options = createOptions('/origin/test-folder/', 'user1')
+      options.headers.origin = origin1
 
-        request.head(options, function (error, response, body) {
-          assert.equal(error, null)
-          assert.equal(response.statusCode, 200)
-          done()
-        })
+      request.head(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 200)
+        done()
       })
     it('agent should be able to access public test directory even when origin is invalid',
       function (done) {
@@ -429,7 +423,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -439,7 +433,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -457,7 +451,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthorized') // TODO: Should be Unauthenticated
+        assert.equal(response.statusMessage, 'Unauthenticated')
         done()
       })
     })
@@ -499,7 +493,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
 
   describe('Append-only', function () {
     // var body = fs.readFileSync(__dirname + '/resources/append-acl/abc.ttl.acl')
-    it("user1 should be able to access test file's ACL file", function (done) {
+    it('user1 should be able to access test file\'s ACL file', function (done) {
       var options = createOptions('/append-acl/abc.ttl.acl', 'user1')
       request.head(options, function (error, response) {
         assert.equal(error, null)
@@ -545,12 +539,12 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it("user2 should not be able to access test file's ACL file", function (done) {
+    it('user2 should not be able to access test file\'s ACL file', function (done) {
       var options = createOptions('/append-acl/abc.ttl.acl', 'user2', 'text/turtle')
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -559,7 +553,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -569,7 +563,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -578,7 +572,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthorized') // TODO: Should be Unauthenticated
+        assert.equal(response.statusMessage, 'Unauthenticated')
         done()
       })
     })
@@ -588,7 +582,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthorized') // TODO: Should be Unauthenticated
+        assert.equal(response.statusMessage, 'Unauthenticated')
         done()
       })
     })
@@ -636,17 +630,16 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it('user2 should be able to write a file in the test directory',
-      function (done) {
-        var options = createOptions('/group/test-folder/test.ttl', 'user2', 'text/turtle')
-        options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
+    it('user2 should be able to write a file in the test directory', function (done) {
+      var options = createOptions('/group/test-folder/test.ttl', 'user2', 'text/turtle')
+      options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
 
-        request.put(options, function (error, response, body) {
-          assert.equal(error, null)
-          assert.equal(response.statusCode, 201)
-          done()
-        })
+      request.put(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 201)
+        done()
       })
+    })
 
     it('user1 should be able to get the file', function (done) {
       var options = createOptions('/group/test-folder/test.ttl', 'user1', 'text/turtle')
@@ -657,18 +650,17 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it('user2 should not be able to write to the ACL',
-      function (done) {
-        var options = createOptions('/group/test-folder/.acl', 'user2', 'text/turtle')
-        options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
+    it('user2 should not be able to write to the ACL', function (done) {
+      var options = createOptions('/group/test-folder/.acl', 'user2', 'text/turtle')
+      options.body = '<#Dahut> a <https://dbpedia.org/resource/Category:French_legendary_creatures>.\n'
 
-        request.put(options, function (error, response, body) {
-          assert.equal(error, null)
-          assert.equal(response.statusCode, 403)
-          assert.equal(response.statusMessage, 'Forbidden')
-          done()
-        })
+      request.put(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 403)
+        assert.equal(response.statusMessage, 'User Unauthorized')
+        done()
       })
+    })
 
     it('user1 should be able to delete the file', function (done) {
       var options = createOptions('/group/test-folder/test.ttl', 'user1', 'text/turtle')
@@ -679,26 +671,24 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it('We should have a 500 with invalid group listings',
-      function (done) {
-        var options = createOptions('/group/test-folder/some-other-file.txt', 'user2')
+    it('We should have a 500 with invalid group listings', function (done) {
+      var options = createOptions('/group/test-folder/some-other-file.txt', 'user2')
 
-        request.get(options, function (error, response, body) {
-          assert.equal(error, null)
-          assert.equal(response.statusCode, 500)
-          done()
-        })
+      request.get(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 500)
+        done()
       })
-    it('We should have a 404 for non-existent file',
-      function (done) {
-        var options = createOptions('/group/test-folder/nothere.txt', 'user2')
+    })
+    it('We should have a 404 for non-existent file', function (done) {
+      var options = createOptions('/group/test-folder/nothere.txt', 'user2')
 
-        request.get(options, function (error, response, body) {
-          assert.equal(error, null)
-          assert.equal(response.statusCode, 404)
-          done()
-        })
+      request.get(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 404)
+        done()
       })
+    })
   })
 
   describe('Restricted', function () {
@@ -710,7 +700,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       ' <http://www.w3.org/ns/auth/acl#accessTo> <./abc2.ttl>;\n' +
       ' <http://www.w3.org/ns/auth/acl#agent> <' + user2 + '>;\n' +
       ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>.\n'
-    it("user1 should be able to modify test file's ACL file", function (done) {
+    it('user1 should be able to modify test file\'s ACL file', function (done) {
       var options = createOptions('/append-acl/abc2.ttl.acl', 'user1', 'text/turtle')
       options.body = body
       request.put(options, function (error, response, body) {
@@ -719,7 +709,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it("user1 should be able to access test file's ACL file", function (done) {
+    it('user1 should be able to access test file\'s ACL file', function (done) {
       var options = createOptions('/append-acl/abc2.ttl.acl', 'user1', 'text/turtle')
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
@@ -752,12 +742,12 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it("user2 should not be able to access test file's ACL file", function (done) {
+    it('user2 should not be able to access test file\'s ACL file', function (done) {
       var options = createOptions('/append-acl/abc2.ttl.acl', 'user2')
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Unauthenticated
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -775,7 +765,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthorized') // TODO: Should be Unauthenticated
+        assert.equal(response.statusMessage, 'Unauthenticated')
         done()
       })
     })
@@ -785,7 +775,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthorized') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'Unauthenticated')
         done()
       })
     })
@@ -807,7 +797,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       ' <http://www.w3.org/ns/auth/acl#default> <./>;\n' +
       ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
       ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
-    it("user1 should be able to modify test directory's ACL file", function (done) {
+    it('user1 should be able to modify test directory\'s ACL file', function (done) {
       var options = createOptions('/write-acl/default-for-new/.acl', 'user1', 'text/turtle')
       options.body = body
       request.put(options, function (error, response, body) {
@@ -816,7 +806,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it("user1 should be able to access test direcotory's ACL file", function (done) {
+    it('user1 should be able to access test direcotory\'s ACL file', function (done) {
       var options = createOptions('/write-acl/default-for-new/.acl', 'user1')
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
@@ -841,12 +831,12 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
-    it("user2 should not be able to access test direcotory's ACL file", function (done) {
+    it('user2 should not be able to access test direcotory\'s ACL file', function (done) {
       var options = createOptions('/write-acl/default-for-new/.acl', 'user2')
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -864,7 +854,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be User Unauthorized
+        assert.equal(response.statusMessage, 'User Unauthorized')
         done()
       })
     })
@@ -882,7 +872,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 401)
-        assert.equal(response.statusMessage, 'Unauthorized') // TODO: Should be Unauthenticated
+        assert.equal(response.statusMessage, 'Unauthenticated')
         done()
       })
     })

--- a/test/integration/acl-tls-test.js
+++ b/test/integration/acl-tls-test.js
@@ -277,13 +277,13 @@ describe('ACL with WebID+TLS', function () {
         'content-type': 'text/turtle'
       }
       options.body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/.acl>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/>;\n' +
         ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
         '<#Public> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
         ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://www.w3.org/ns/auth/acl#AuthenticatedAgent>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
       request.put(options, function (error, response, body) {
@@ -326,13 +326,13 @@ describe('ACL with WebID+TLS', function () {
           done()
         })
       })
-    it('agent should be able to access test directory', function (done) {
+    it('agent not should be able to access test directory', function (done) {
       var options = createOptions('/acl-tls/origin/test-folder/')
       options.headers.origin = origin1
 
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
+        assert.equal(response.statusCode, 403)
         done()
       })
     })
@@ -375,16 +375,16 @@ describe('ACL with WebID+TLS', function () {
         'content-type': 'text/turtle'
       }
       options.body = '<#Owner1> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/.acl>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/>;\n' +
         ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
         '<#Owner2> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-          ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/.acl>;\n' +
+          ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/>;\n' +
           ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
           ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
         '<#Public> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
         ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://www.w3.org/ns/auth/acl#AuthenticatedAgent>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
       request.put(options, function (error, response, body) {
@@ -427,13 +427,13 @@ describe('ACL with WebID+TLS', function () {
           done()
         })
       })
-    it('agent should be able to access test directory', function (done) {
+    it('agent should not be able to access test directory for logged in users', function (done) {
       var options = createOptions('/acl-tls/origin/test-folder/')
       options.headers.origin = origin1
 
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
+        assert.equal(response.statusCode, 403)
         done()
       })
     })


### PR DESCRIPTION
This should fix https://github.com/solid/node-solid-server/issues/468 .

There might be a couple of quota-related tests that fail (they do on my local setup), which is weird, as these changes should not affect that code.

@kjetilk and I are working on the same files, so if this PR is merged before his, I'll do the work when his PR is ready to be merged.