### PR TITLE
Improve tests given that origin doesn't matter for public resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -202,9 +202,9 @@
       }
     },
     "@solid/acl-check": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@solid/acl-check/-/acl-check-0.1.2.tgz",
-      "integrity": "sha512-1e9/HAyRARpVUXpAGtNILF+mnCdIljkbAoLjRrgI1jb5CEMEdsP94iu4ADlC+aoIZob6hsDpoo975oB2nMqqew==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@solid/acl-check/-/acl-check-0.1.3.tgz",
+      "integrity": "sha512-Rvdxn7SOlqo1BtiY6dcFlJAjne0QK1hrsFL1q3HUDg7yleOEXBm1ESyZ0XDM6jwqJHqKf+0l987D15k5MPyIng==",
       "requires": {
         "rdflib": "^0.12.1",
         "solid-namespace": "0.1.0"
@@ -212,7 +212,7 @@
       "dependencies": {
         "rdflib": {
           "version": "0.12.3",
-          "resolved": "http://registry.npmjs.org/rdflib/-/rdflib-0.12.3.tgz",
+          "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-0.12.3.tgz",
           "integrity": "sha1-K0IGamYJwGtAqQSFhJNix8uV6h4=",
           "requires": {
             "async": "^0.9.x",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "bugs": "https://github.com/solid/node-solid-server/issues",
   "dependencies": {
     "@solid/oidc-auth-manager": "^0.17.1",
-    "@solid/acl-check": "^0.1.2",
+    "@solid/acl-check": "^0.1.3",
     "body-parser": "^1.18.3",
     "bootstrap": "^3.3.7",
     "busboy": "^0.2.12",

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -255,7 +255,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
     })
   })
 
-  describe.only('Origin', function () {
+  describe('Origin', function () {
     before(function () {
       rm('/accounts-acl/tim.localhost/origin/test-folder/.acl')
     })

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -311,15 +311,14 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
-    it('user1 should not be able to access test directory when origin is invalid',
+    it('user1 should be able to access public test directory even when origin is invalid',
       function (done) {
         var options = createOptions('/origin/test-folder/', 'user1')
         options.headers.origin = origin2
 
         request.head(options, function (error, response, body) {
           assert.equal(error, null)
-          assert.equal(response.statusCode, 403)
-          assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
+          assert.equal(response.statusCode, 200)
           done()
         })
       })
@@ -344,15 +343,14 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
-    it('agent should not be able to access test directory when origin is invalid',
+    it('agent should be able to access public test directory even when origin is invalid',
       function (done) {
         var options = createOptions('/origin/test-folder/')
         options.headers.origin = origin2
 
         request.head(options, function (error, response, body) {
           assert.equal(error, null)
-          assert.equal(response.statusCode, 403)
-          assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
+          assert.equal(response.statusCode, 200)
           done()
         })
       })

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -255,7 +255,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
     })
   })
 
-  describe('Origin', function () {
+  describe.only('Origin', function () {
     before(function () {
       rm('/accounts-acl/tim.localhost/origin/test-folder/.acl')
     })
@@ -271,7 +271,13 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
         ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n' +
+        '<#Somebody> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agent> <' + user2 + '>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#default> <./>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Write> .\n'
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 201)
@@ -354,9 +360,32 @@ describe('ACL with WebID+OIDC over HTTP', function () {
           done()
         })
       })
+    it('user2 should be able to write to test directory with correct origin', function (done) {
+      var options = createOptions('/origin/test-folder/test1.txt', 'user2', 'text/plain')
+      options.headers.origin = origin1
+      options.body = 'DAAAAAHUUUT'
+      request.put(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 201)
+        done()
+      })
+    })
+    it('user2 should not be able to write to test directory with wrong origin', function (done) {
+      var options = createOptions('/origin/test-folder/test2.txt', 'user2', 'text/plain')
+      options.headers.origin = origin2
+      options.body = 'ARRRRGH'
+      request.put(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 403)
+        assert.equal(response.statusMessage, 'Origin Unauthorized')
+        done()
+      })
+    })
 
     after(function () {
       rm('/accounts-acl/tim.localhost/origin/test-folder/.acl')
+      rm('/accounts-acl/tim.localhost/origin/test-folder/test1.txt')
+      rm('/accounts-acl/tim.localhost/origin/test-folder/test2.txt')
     })
   })
 

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -290,6 +290,16 @@ describe('ACL with WebID+OIDC over HTTP', function () {
         done()
       })
     })
+    it('user2 should be able to access public test directory with wrong origin', function (done) {
+      var options = createOptions('/origin/test-folder/', 'user2')
+      options.headers.origin = origin2
+
+      request.head(options, function (error, response, body) {
+        assert.equal(error, null)
+        assert.equal(response.statusCode, 200)
+        done()
+      })
+    })
     it('user1 should be able to access to test directory when origin is valid',
       function (done) {
         var options = createOptions('/origin/test-folder/', 'user1')

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -377,7 +377,7 @@ describe('ACL with WebID+OIDC over HTTP', function () {
       request.put(options, function (error, response, body) {
         assert.equal(error, null)
         assert.equal(response.statusCode, 403)
-        assert.equal(response.statusMessage, 'Origin Unauthorized')
+        assert.equal(response.statusMessage, 'Forbidden') // TODO: Should be Origin Unauthorized
         done()
       })
     })

--- a/test/integration/acl-tls-test.js
+++ b/test/integration/acl-tls-test.js
@@ -277,7 +277,7 @@ describe('ACL with WebID+TLS', function () {
         'content-type': 'text/turtle'
       }
       options.body = '<#Owner> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/.acl>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/>;\n' +
         ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
@@ -375,11 +375,11 @@ describe('ACL with WebID+TLS', function () {
         'content-type': 'text/turtle'
       }
       options.body = '<#Owner1> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/.acl>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/>;\n' +
         ' <http://www.w3.org/ns/auth/acl#agent> <' + user1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
         '<#Owner2> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
-          ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/.acl>;\n' +
+          ' <http://www.w3.org/ns/auth/acl#accessTo> <https://localhost:3456/test/acl-tls/origin/test-folder/>;\n' +
           ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
           ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
         '<#Public> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +

--- a/test/integration/acl-tls-test.js
+++ b/test/integration/acl-tls-test.js
@@ -283,7 +283,7 @@ describe('ACL with WebID+TLS', function () {
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
         '<#Public> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
         ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://www.w3.org/ns/auth/acl#AuthenticatedAgent>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
       request.put(options, function (error, response, body) {
@@ -326,13 +326,13 @@ describe('ACL with WebID+TLS', function () {
           done()
         })
       })
-    it('agent should be able to access test directory', function (done) {
+    it('agent not should be able to access test directory', function (done) {
       var options = createOptions('/acl-tls/origin/test-folder/')
       options.headers.origin = origin1
 
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
+        assert.equal(response.statusCode, 403)
         done()
       })
     })
@@ -384,7 +384,7 @@ describe('ACL with WebID+TLS', function () {
           ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read>, <http://www.w3.org/ns/auth/acl#Write>, <http://www.w3.org/ns/auth/acl#Control> .\n' +
         '<#Public> a <http://www.w3.org/ns/auth/acl#Authorization>;\n' +
         ' <http://www.w3.org/ns/auth/acl#accessTo> <./>;\n' +
-        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent>;\n' +
+        ' <http://www.w3.org/ns/auth/acl#agentClass> <http://www.w3.org/ns/auth/acl#AuthenticatedAgent>;\n' +
         ' <http://www.w3.org/ns/auth/acl#origin> <' + origin1 + '>;\n' +
         ' <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n'
       request.put(options, function (error, response, body) {
@@ -427,13 +427,13 @@ describe('ACL with WebID+TLS', function () {
           done()
         })
       })
-    it('agent should be able to access test directory', function (done) {
+    it('agent should not be able to access test directory for logged in users', function (done) {
       var options = createOptions('/acl-tls/origin/test-folder/')
       options.headers.origin = origin1
 
       request.head(options, function (error, response, body) {
         assert.equal(error, null)
-        assert.equal(response.statusCode, 200)
+        assert.equal(response.statusCode, 403)
         done()
       })
     })


### PR DESCRIPTION
Given the bug in https://github.com/solid/acl-check/issues/15, we changed the behavior to https://github.com/solid/acl-check/issues/16. To complete, it also requires #1042 to be merged.

This became surprisingly complex, for several reasons:

1. We tended to test for `Origin` only on public resources, which made the tests somewhat irrelevant.
2. The ACL we tested against had `acl:accessTo <[...].acl>` statements, which are wrong.
3. We needed more tests to really test `Origin`.
4. The message checking in #1042 was worked on in parallell.

But it should be OK now.
