### PR TITLE
Explicitly list Accept header for CORS.

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -30,7 +30,7 @@ const corsSettings = cors({
   methods: [
     'OPTIONS', 'HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'
   ],
-  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate',
+  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate',
   credentials: true,
   maxAge: 1728000,
   origin: true,


### PR DESCRIPTION
Should fix

> Access to fetch at 'https://www.w3.org/People/Berners-Lee/card' from origin 'https://timbl.com' has been blocked by CORS policy: Request header field accept is not allowed by Access-Control-Allow-Headers in preflight response.