### PR TITLE
Make CORS proxy follow redirects

### DIFF
--- a/lib/handlers/cors-proxy.js
+++ b/lib/handlers/cors-proxy.js
@@ -19,6 +19,8 @@ const PROXY_SETTINGS = {
   target: 'dynamic',
   logLevel: 'silent',
   changeOrigin: true,
+  followRedirects: true,
+  proxyTimeout: 5000,
   router: req => req.destination.target,
   pathRewrite: (path, req) => req.destination.path
 }


### PR DESCRIPTION
Implements https://github.com/solid/node-solid-server/issues/1069 .

http-proxy-middleware has an option to `followRedirects`. http-proxy has max redirects set to 10.

I've also set the `proxyTimeout` to 5 seconds (arbitrary but reasonable I guess).

