### PR TITLE
Add an origin that can be trusted by default

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -12,7 +12,7 @@ module.exports = {
   'serverUri': 'https://localhost:8443',
   'webid': true,
   'strictOrigin': true,
-  'trustedOrigins': ['https://apps.solid.invalid'],
+  'trustedOrigins': ['https://app.solidproject.org'],
   'dataBrowserPath': 'default'
 
   // For use in Enterprises to configure a HTTP proxy for all outbound HTTP requests from the SOLID server (we use

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -271,7 +271,7 @@ describe('Authentication API (OIDC)', () => {
           before(done => {
             alice.get('/')
               .set('Cookie', cookie)
-              .set('Origin', 'https://apps.solid.invalid')
+              .set('Origin', 'https://app.solidproject.org')
               .end((err, res) => {
                 response = res
                 done(err)


### PR DESCRIPTION
To ease deployment of apps, we add an origin that can be trusted by default, but now controlled by the Solid project.

It can be overridden in the server config.