### PR TITLE
missing foaf prefix in account root .acl

### DIFF
--- a/default-templates/new-account/.acl
+++ b/default-templates/new-account/.acl
@@ -1,5 +1,6 @@
 # Root ACL resource for the user account
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
 # The homepage is readable by the public
 <#public>


### PR DESCRIPTION
maybe to avoid invalid turtle in the future all .acl files could get checked with https://github.com/IDLabResearch/TurtleValidator on CI