### PR TITLE
Fixed so that relative paths are allowed in root param

### DIFF
--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -2,6 +2,7 @@
 
 const options = require('./options')
 const fs = require('fs')
+const path = require('path')
 const { loadConfig } = require('./cli-utils')
 const { red, bold } = require('colorette')
 
@@ -84,10 +85,7 @@ function bin (argv, server) {
 
   // Overwrite root .acl if owner is specified
   if (argv.owner) {
-    let rootPath = argv.root
-    if (!rootPath) {
-      rootPath = process.cwd()
-    }
+    let rootPath = path.resolve(argv.root || process.cwd())
     if (!(rootPath.endsWith('/'))) {
       rootPath += '/'
     }

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -45,7 +45,7 @@ function createApp (argv = {}) {
 
   argv.resourceMapper = new ResourceMapper({
     rootUrl: argv.serverUri,
-    rootPath: argv.root || process.cwd(),
+    rootPath: path.resolve(argv.root || process.cwd()),
     includeHost: argv.multiuser,
     defaultContentType: argv.defaultContentType
   })
@@ -64,6 +64,7 @@ function createApp (argv = {}) {
 
   // Serve the public 'common' directory (for shared CSS files, etc)
   app.use('/common', express.static(path.join(__dirname, '../common')))
+  routeResolvedFile(app, '/common/js/', 'mashlib/dist/mashlib.js')
   routeResolvedFile(app, '/common/js/', 'mashlib/dist/mashlib.min.js')
   routeResolvedFile(app, '/common/js/', 'mashlib/dist/mashlib.min.js.map')
   routeResolvedFile(app, '/common/js/', 'solid-auth-client/dist-lib/solid-auth-client.bundle.js')

--- a/test/integration/params-test.js
+++ b/test/integration/params-test.js
@@ -56,7 +56,7 @@ describe('LDNODE params', function () {
       var server = supertest(ldp)
 
       it('should fallback on current working directory', function () {
-        assert.equal(ldp.locals.ldp.resourceMapper._rootPath, './test/resources')
+        assert.equal(ldp.locals.ldp.resourceMapper._rootPath, path.resolve('./test/resources'))
       })
 
       it('should find resource in correct path', function (done) {


### PR DESCRIPTION
Whether or not this should be allowed is another question. But if we want to allow it, this fix should solve it.

This is a possible fix for https://github.com/solid/node-solid-server/issues/1068.