### PR TITLE
trustedOrigins is empty by default

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -12,7 +12,7 @@ module.exports = {
   'serverUri': 'https://localhost:8443',
   'webid': true,
   'strictOrigin': true,
-  'trustedOrigins': ['https://apps.solid.invalid'],
+  'trustedOrigins': [],
   'dataBrowserPath': 'default'
 
   // For use in Enterprises to configure a HTTP proxy for all outbound HTTP requests from the SOLID server (we use

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -42,7 +42,8 @@ describe('Authentication API (OIDC)', () => {
     dataBrowser: false,
     webid: true,
     multiuser: false,
-    configPath
+    configPath,
+    trustedOrigins: ['https://apps.solid.invalid']
   }
 
   const aliceRootPath = path.join(__dirname, '../resources/accounts-scenario/alice')


### PR DESCRIPTION
As requested in https://github.com/solid/node-solid-server/issues/1090.