### PR TITLE
Report server version in X-Powered-By header

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -25,7 +25,7 @@ const path = require('path')
 const { routeResolvedFile } = require('./utils')
 const ResourceMapper = require('./resource-mapper')
 const aclCheck = require('@solid/acl-check')
-const version = require('../package.json').version
+const { version } = require('../package.json')
 
 const corsSettings = cors({
   methods: [

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -25,6 +25,7 @@ const path = require('path')
 const { routeResolvedFile } = require('./utils')
 const ResourceMapper = require('./resource-mapper')
 const aclCheck = require('@solid/acl-check')
+const version = require('../package.json').version
 
 const corsSettings = cors({
   methods: [
@@ -154,7 +155,7 @@ function initHeaders (app) {
   app.use(corsSettings)
 
   app.use((req, res, next) => {
-    res.set('X-Powered-By', 'solid-server')
+    res.set('X-Powered-By', 'solid-server/' + version)
 
     // Cors lib adds Vary: Origin automatically, but inreliably
     res.set('Vary', 'Accept, Authorization, Origin')


### PR DESCRIPTION
I propose we report the server version in the `X-Powered-By` header. When users report errors, we will sometimes need to stop to ask them to verify the version.

Now, some say it has security implications, since if people aren't upgrading when facing security problems, a spider can map vulnerable servers. However, we are now at a prototype, and we are likely to need to help users, and so it should not be as much of a concern.