### PR TITLE
Proxy updates

### DIFF
--- a/lib/handlers/cors-proxy.js
+++ b/lib/handlers/cors-proxy.js
@@ -20,7 +20,7 @@ const PROXY_SETTINGS = {
   logLevel: 'silent',
   changeOrigin: true,
   followRedirects: true,
-  proxyTimeout: 5000,
+  proxyTimeout: 10000,
   router: req => req.destination.target,
   pathRewrite: (path, req) => req.destination.path
 }

--- a/lib/handlers/cors-proxy.js
+++ b/lib/handlers/cors-proxy.js
@@ -11,7 +11,7 @@ const validUrl = require('valid-url')
 
 const CORS_SETTINGS = {
   methods: 'GET',
-  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, Content-Length',
+  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, Content-Length, Content-Location',
   maxAge: 1728000,
   origin: true
 }


### PR DESCRIPTION
Addresses issue https://github.com/solid/node-solid-server/issues/1099 where 5s wasn't reliable in the case of archiving.

Address issue https://github.com/solid/node-solid-server/issues/1101 by adding `Content-Location` header to `Access-Control-Expose-Headers`.