### PR TITLE
Display server version at startup when not running from git repository

### DIFF
--- a/bin/lib/cli.js
+++ b/bin/lib/cli.js
@@ -25,10 +25,15 @@ function getVersion () {
     // Obtain version from git
     const options = { cwd: __dirname, encoding: 'utf8' }
     const { stdout } = spawnSync('git', ['describe', '--tags'], options)
-    return stdout.trim()
+    const version = stdout.trim()
+    if (version === '') {
+      throw new Error('No git version here')
+    }
+    return version
   } catch (e) {
     // Obtain version from package.json
     const { version } = require(path.join(__dirname, '../../package.json'))
     return version
   }
 }
+


### PR DESCRIPTION
See #1110, #1111 

This fix raises an error when the version information returned by running git is empty, thereby falling back to using package.json.  (This is a new attempt to submit previous PR #1111, but this time based upon and updating the release/v5.0.0 branch.)