### PR TITLE
Extract printing debug info from ldp to config module

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -54,6 +54,8 @@ function createApp (argv = {}) {
   const configPath = config.initConfigDir(argv)
   argv.templates = config.initTemplateDirs(configPath)
 
+  config.printDebugInfo(argv)
+
   const ldp = new LDP(argv)
 
   const app = express()

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -63,21 +63,6 @@ class LDP {
       this.corsProxy = '/' + this.corsProxy
     }
 
-    debug.settings('Server URI: ' + this.serverUri)
-    debug.settings('Auth method: ' + this.auth)
-    debug.settings('Strict origins: ' + this.strictOrigin)
-    debug.settings('Allowed origins: ' + this.trustedOrigins)
-    debug.settings('Db path: ' + this.dbPath)
-    debug.settings('Config path: ' + this.configPath)
-    debug.settings('Suffix Acl: ' + this.suffixAcl)
-    debug.settings('Suffix Meta: ' + this.suffixMeta)
-    debug.settings('Filesystem Root: ' + (this.resourceMapper ? this.resourceMapper.rootPath : 'none'))
-    debug.settings('Allow WebID authentication: ' + !!this.webid)
-    debug.settings('Live-updates: ' + !!this.live)
-    debug.settings('Multi-user: ' + !!this.multiuser)
-    debug.settings('Suppress default data browser app: ' + this.suppressDataBrowser)
-    debug.settings('Default data browser app file path: ' + this.dataBrowserPath)
-
     return this
   }
 

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -9,6 +9,25 @@ const path = require('path')
 const templateUtils = require('./common/template-utils')
 const fsUtils = require('./common/fs-utils')
 
+const debug = require('./debug')
+
+function printDebugInfo (options) {
+  debug.settings('Server URI: ' + options.serverUri)
+  debug.settings('Auth method: ' + options.auth)
+  debug.settings('Strict origins: ' + options.strictOrigin)
+  debug.settings('Allowed origins: ' + options.trustedOrigins)
+  debug.settings('Db path: ' + options.dbPath)
+  debug.settings('Config path: ' + options.configPath)
+  debug.settings('Suffix Acl: ' + options.suffixAcl)
+  debug.settings('Suffix Meta: ' + options.suffixMeta)
+  debug.settings('Filesystem Root: ' + (this.resourceMapper ? this.resourceMapper.rootPath : 'none'))
+  debug.settings('Allow WebID authentication: ' + !!options.webid)
+  debug.settings('Live-updates: ' + !!options.live)
+  debug.settings('Multi-user: ' + !!options.multiuser)
+  debug.settings('Suppress default data browser app: ' + options.suppressDataBrowser)
+  debug.settings('Default data browser app file path: ' + options.dataBrowserPath)
+}
+
 /**
  * Ensures that a directory has been copied / initialized. Used to ensure that
  * account templates, email templates and default apps have been copied from
@@ -144,5 +163,6 @@ module.exports = {
   ensureWelcomePage,
   initConfigDir,
   initDefaultViews,
-  initTemplateDirs
+  initTemplateDirs,
+  printDebugInfo
 }


### PR DESCRIPTION
Minor refactor - extract the printing out of debug info from LDP constructor to the `server-config` module.
Extracted from PR #702, partly addresses issue #483.