### PR TITLE
Expand SolidHost config constructor, plus tests

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -42,7 +42,7 @@ function createApp (argv = {}) {
   // Override default configs (defaults) with passed-in params (argv)
   argv = Object.assign({}, defaults, argv)
 
-  argv.host = SolidHost.from({ port: argv.port, serverUri: argv.serverUri })
+  argv.host = SolidHost.from(argv)
 
   argv.resourceMapper = new ResourceMapper({
     rootUrl: argv.serverUri,

--- a/lib/models/solid-host.js
+++ b/lib/models/solid-host.js
@@ -15,7 +15,12 @@ class SolidHost {
    * @param [options={}]
    * @param [options.port] {number}
    * @param [options.serverUri] {string} Fully qualified URI that this Solid
-   *   server is listening on, e.g. `https://databox.me`
+   *   server is listening on, e.g. `https://solid.community`
+   * @param [options.live] {boolean} Whether to turn on WebSockets / LDP live
+   * @param [options.root] {string} Path to root data directory
+   * @param [options.multiuser] {boolean} Multiuser mode
+   * @param [options.webid] {boolean} Enable WebID-related functionality
+   *  (account creation and authentication)
    */
   constructor (options = {}) {
     this.port = options.port || defaults.port
@@ -24,6 +29,10 @@ class SolidHost {
     this.parsedUri = url.parse(this.serverUri)
     this.host = this.parsedUri.host
     this.hostname = this.parsedUri.hostname
+    this.live = options.live
+    this.root = options.root
+    this.multiuser = options.multiuser
+    this.webid = options.webid
   }
 
   /**

--- a/test/unit/solid-host-test.js
+++ b/test/unit/solid-host-test.js
@@ -7,16 +7,24 @@ const defaults = require('../../config/defaults')
 
 describe('SolidHost', () => {
   describe('from()', () => {
-    it('should init with port, serverUri and hostname', () => {
+    it('should init with provided params', () => {
       let config = {
         port: 3000,
-        serverUri: 'https://localhost:3000'
+        serverUri: 'https://localhost:3000',
+        live: true,
+        root: '/data/solid/',
+        multiuser: true,
+        webid: true
       }
       let host = SolidHost.from(config)
 
       expect(host.port).to.equal(3000)
       expect(host.serverUri).to.equal('https://localhost:3000')
       expect(host.hostname).to.equal('localhost')
+      expect(host.live).to.be.true
+      expect(host.root).to.equal('/data/solid/')
+      expect(host.multiuser).to.be.true
+      expect(host.webid).to.be.true
     })
 
     it('should init to default port and serverUri values', () => {


### PR DESCRIPTION
Minor refactor, expand the `SolidHost` constructor.

Extracted from PR #702, partly addresses issue #483.