### PR TITLE
Changing startup behavior around config file

### DIFF
--- a/bin/lib/cli-utils.js
+++ b/bin/lib/cli-utils.js
@@ -42,19 +42,19 @@ function loadConfig (program, options) {
     argv = { ...config, ...argv }
   } catch (err) {
     // If config file was specified, but it doesn't exist, stop with error message
-    if(typeof argv['configFile'] !== 'undefined') {
-      if (! fs.existsSync(configFile)) {
-        console.log(red(bold('ERR')), 'Config file '+configFile+' doesn\'t exist.')
+    if (typeof argv['configFile'] !== 'undefined') {
+      if (!fs.existsSync(configFile)) {
+        console.log(red(bold('ERR')), 'Config file ' + configFile + ' doesn\'t exist.')
         process.exit(1)
       }
     }
-    
+
     // If the file exists, but parsing failed, stop with error message
     if (fs.existsSync(configFile)) {
-      console.log(red(bold('ERR')), 'config file '+configFile+' couldn\'t be parsed: '+err)
+      console.log(red(bold('ERR')), 'config file ' + configFile + ' couldn\'t be parsed: ' + err)
       process.exit(1)
     }
-    
+
     // Legacy behavior - if config file does not exist, start with default
     // values, but an info message to create a config file.
     console.log(cyan(bold('TIP')), 'create a config.json: `$ solid init`')

--- a/bin/lib/cli-utils.js
+++ b/bin/lib/cli-utils.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra')
-const { cyan, bold } = require('colorette')
+const { red, cyan, bold } = require('colorette')
 const { URL } = require('url')
 const LDP = require('../../lib/ldp')
 const AccountManager = require('../../lib/models/account-manager')
@@ -41,7 +41,22 @@ function loadConfig (program, options) {
     const config = JSON.parse(file)
     argv = { ...config, ...argv }
   } catch (err) {
-    // No file exists, not a problem
+    // If config file was specified, but it doesn't exist, stop with error message
+    if(typeof argv['configFile'] !== 'undefined') {
+      if (! fs.existsSync(configFile)) {
+        console.log(red(bold('ERR')), 'Config file '+configFile+' doesn\'t exist.')
+        process.exit(1)
+      }
+    }
+    
+    // If the file exists, but parsing failed, stop with error message
+    if (fs.existsSync(configFile)) {
+      console.log(red(bold('ERR')), 'config file '+configFile+' couldn\'t be parsed: '+err)
+      process.exit(1)
+    }
+    
+    // Legacy behavior - if config file does not exist, start with default
+    // values, but an info message to create a config file.
     console.log(cyan(bold('TIP')), 'create a config.json: `$ solid init`')
   }
 


### PR DESCRIPTION
If user specifies a config file, but it doesn't exist - notify and fail
Else If config file exists, but it can't be parsed - notify and fail
Else fall back to legacy behavior - any exception will tell user to create a config file and startup with default config
