### PR TITLE
Delete .acl file for resource when resource is deleted

### DIFF
--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -412,7 +412,7 @@ class LDP {
     }
 
     // Ensure the container is empty (we ignore .meta and .acl)
-    if (list.some(file => file !== this.suffixMeta && file !== this.suffixAcl)) {
+    if (list.some(file => !file.endsWith(this.suffixMeta) && !file.endsWith(this.suffixAcl))) {
       throw error(409, 'Container is not empty')
     }
 
@@ -424,9 +424,27 @@ class LDP {
     }
   }
 
+  async deleteResourceAcl (path) {
+    const unlink = promisify(fs.unlink)
+    const stat = promisify(fs.stat)
+    const aclPath = `${path}${this.suffixAcl}`
+    const aclStat = await stat(aclPath)
+    // Ignore any errors
+      .catch(() => undefined)
+    if (!(aclStat && aclStat.isFile())) {
+      // No need to try and delete if it isn't a file
+      return
+    }
+    // Delete the file
+    await unlink(aclPath)
+  }
+
   async deleteResource (path) {
     try {
-      return await withLock(path, { mustExist: false }, () => promisify(fs.unlink)(path))
+      return await withLock(path, { mustExist: false }, () => Promise.all([
+        promisify(fs.unlink)(path),
+        this.deleteResourceAcl(path)
+      ]))
     } catch (err) {
       debug.container('DELETE -- unlink() error: ' + err)
       throw error(err, 'Failed to delete resource')

--- a/test/resources/accounts-scenario/alice/db/oidc/op/clients/_key_24dc4f2ccf3ffce7392d33e6761f5a71.json
+++ b/test/resources/accounts-scenario/alice/db/oidc/op/clients/_key_24dc4f2ccf3ffce7392d33e6761f5a71.json
@@ -1,0 +1,1 @@
+{"client_id":"24dc4f2ccf3ffce7392d33e6761f5a71","redirect_uris":["https://app.example.com/callback"],"response_types":["id_token token"],"grant_types":["implicit"],"application_type":"web","id_token_signed_response_alg":"RS256","token_endpoint_auth_method":"client_secret_basic","frontchannel_logout_session_required":false}

--- a/test/settings/serverSide.ttl
+++ b/test/settings/serverSide.ttl
@@ -10,5 +10,3 @@
 
 </>
     solid:storageQuota "1230" .
-    
-    


### PR DESCRIPTION
Delete .acl file for resource when resource is deleted, also ignore any acl or meta files in directory when deleting. 

I had troubles with some TLS not passing, locally I skipped them. I also had issues with the quota tests, its like the signature of ldp changed at some point, so I redid the test so it tests correctly. 