### PR TITLE
Just remove the superfluous unit prefix that never got into spec

### DIFF
--- a/default-templates/new-account/settings/serverSide.ttl.inactive
+++ b/default-templates/new-account/settings/serverSide.ttl.inactive
@@ -1,7 +1,6 @@
 @prefix dct: <http://purl.org/dc/terms/>.
 @prefix pim: <http://www.w3.org/ns/pim/space#>.
 @prefix solid: <http://www.w3.org/ns/solid/terms#>.
-@prefix unit: <http://www.w3.invalid/ns#>.
 
 <>
   a pim:ConfigurationFile;


### PR DESCRIPTION
Just a tiny little no-op thing that should be removed.