### PR TITLE
Make application/octet-stream the default Content-Type

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -247,13 +247,6 @@ function _asyncReadfile (filename) {
  * @return {string} A content type string
  */
 function getContentType (headers) {
-  const headerValue = headers.get ? headers.get('content-type') : headers['content-type']
-
-  // Default content type as stated by RFC 822
-  if (!headerValue) {
-    return 'text/plain'
-  }
-
-  // Remove charset suffix
-  return headerValue.split(';')[0]
+  const value = headers.get ? headers.get('content-type') : headers['content-type']
+  return value ? value.replace(/;.*/, '') : 'application/octet-stream'
 }

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -73,8 +73,8 @@ describe('Utility functions', function () {
 
   describe('getContentType()', () => {
     describe('for Express headers', () => {
-      it('should default to text/plain', () => {
-        assert.equal(utils.getContentType({}), 'text/plain')
+      it('should default to application/octet-stream', () => {
+        assert.equal(utils.getContentType({}), 'application/octet-stream')
       })
 
       it('should get a basic content type', () => {
@@ -87,9 +87,9 @@ describe('Utility functions', function () {
     })
 
     describe('for Fetch API headers', () => {
-      it('should default to text/plain', () => {
+      it('should default to application/octet-stream', () => {
         // eslint-disable-next-line no-undef
-        assert.equal(utils.getContentType(new Headers({})), 'text/plain')
+        assert.equal(utils.getContentType(new Headers({})), 'application/octet-stream')
       })
 
       it('should get a basic content type', () => {


### PR DESCRIPTION
See:
- https://github.com/solid/node-solid-server/issues/1245#issuecomment-509390003
- https://github.com/solid/node-solid-server/issues/1256#issuecomment-509385407