### PR TITLE
Removing externalWebId from account creation form

### DIFF
--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -63,14 +63,6 @@
             <span class="help-block">Your email will only be used for account recovery</span>
           </div>
 
-          <div class="form-group">
-            <label class="control-label" for="externalWebId">External WebID:</label>
-            <input type="text" class="form-control" name="externalWebId" id="externalWebId"/>
-            <span class="help-block">
-                We will generate a Web ID when you register, but if you already have a Web ID hosted elsewhere that you'd prefer to use to log in, enter it here
-            </span>
-          </div>
-
           {{#if enforceToc}}
             {{#if tocUri}}
               <div class="checkbox">


### PR DESCRIPTION
Partially solves https://github.com/solid/node-solid-server/issues/1267 - need to implement an API that allows users to configure their externalWebID elsewhere.

We'll discuss this with rest of the team tomorrow. Might discard this PR until we have an API and interface that allows for editing externalWebID.