### PR TITLE
External web id as opt in

### DIFF
--- a/common/js/auth-buttons.js
+++ b/common/js/auth-buttons.js
@@ -43,7 +43,6 @@
   // Redirect to the registration page
   function register () {
     const registration = new URL('/register', location)
-    registration.searchParams.set('returnToUrl', location)
     location.href = registration
   }
 })(solid)

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -66,7 +66,7 @@
           <div class="checkbox">
             <label>
               <input type="checkbox" name="connectExternalWebId" value="true" id="ConnectExternalWebId" {{#if connectExternalWebId}}checked{{/if}}/>
-              Connect to External WebID (<strong>Advanced feature</strong>
+              Connect to External WebID (<strong>Advanced feature</strong>)
             </label>
           </div>
 

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -63,11 +63,18 @@
             <span class="help-block">Your email will only be used for account recovery</span>
           </div>
 
-          <div class="form-group">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" name="connectExternalWebId" value="true" id="ConnectExternalWebId" {{#if connectExternalWebId}}checked{{/if}}/>
+              Connect to External WebID (<strong>Advanced feature</strong> {{ connectExternalWebId ? "true" : "false" }})
+            </label>
+          </div>
+
+          <div class="form-group hidden" id="ExternalWebId">
             <label class="control-label" for="externalWebId">External WebID:</label>
             <input type="text" class="form-control" name="externalWebId" id="externalWebId" value="{{externalWebId}}"/>
             <span class="help-block">
-                We will generate a Web ID when you register, but if you already have a Web ID hosted elsewhere that you'd prefer to use to log in, enter it here
+              By connecting this account with an existing webId, you can use that webId to authenticate with the new account.
             </span>
           </div>
 
@@ -75,7 +82,7 @@
             {{#if tocUri}}
               <div class="checkbox">
                 <label>
-                  <input type="checkbox" name="acceptToc" value="true" {{acceptToc ? "checked" : ""}}>
+                  <input type="checkbox" name="acceptToc" value="true" {{#if acceptToc}}checked{{/if}}>
                   I agree to the <a href="{{tocUri}}" target="_blank">Terms &amp; Conditions</a> of this service
                 </label>
               </div>
@@ -114,10 +121,19 @@
 <script>
   var username = document.getElementById('username');
   username.onkeyup = function() {
-  var list = document.getElementsByClassName('editable-username');
-  for (let item of list) {
-    item.innerHTML = username.value.toLowerCase()
+    var list = document.getElementsByClassName('editable-username');
+      for (let item of list) {
+      item.innerHTML = username.value.toLowerCase()
+    }
   }
-}
+
+  window.addEventListener('DOMContentLoaded', function () {
+    var connect = document.getElementById('ConnectExternalWebId')
+    var container = document.getElementById('ExternalWebId')
+    container.classList.toggle('hidden', !connect.checked)
+    connect.addEventListener('change', function () {
+      container.classList.toggle('hidden', !connect.checked)
+    })
+  })
 </script>
 

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -66,7 +66,7 @@
           <div class="checkbox">
             <label>
               <input type="checkbox" name="connectExternalWebId" value="true" id="ConnectExternalWebId" {{#if connectExternalWebId}}checked{{/if}}/>
-              Connect to External WebID (<strong>Advanced feature</strong> {{ connectExternalWebId ? "true" : "false" }})
+              Connect to External WebID (<strong>Advanced feature</strong>
             </label>
           </div>
 

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -2,7 +2,7 @@
   <div class="col-md-6">
     <div class="panel panel-default">
       <div class="panel-body">
-        <form method="post" action="/api/accounts/new">
+        <form method="post" action="/api/accounts/new" id="RegisterForm">
           {{> shared/error}}
 
           <div class="form-group">
@@ -133,6 +133,14 @@
     container.classList.toggle('hidden', !connect.checked)
     connect.addEventListener('change', function () {
       container.classList.toggle('hidden', !connect.checked)
+    })
+
+    var form = document.getElementById('RegisterForm')
+    var externalWebIdField = document.getElementById('externalWebId')
+    form.addEventListener('submit', function () {
+      if (!connect.checked) {
+        externalWebIdField.value = ''
+      }
     })
   })
 </script>

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -8,7 +8,7 @@
           <div class="form-group">
             <label class="control-label" for="username">Username*</label>
             <input type="text" class="form-control" name="username" id="username" placeholder="alice"
-                   required/>
+                   required value="{{username}}"/>
 
 	    {{#if multiuser}}
 	    <p>Your username should be a lower-case word with only
@@ -54,18 +54,18 @@
 
           <div class="form-group">
             <label class="control-label" for="name">Name*</label>
-            <input type="text" class="form-control" name="name" id="name" required/>
+            <input type="text" class="form-control" name="name" id="name" required value="{{name}}"/>
           </div>
 
           <div class="form-group">
             <label class="control-label" for="email">Email*</label>
-            <input type="email" class="form-control" name="email" id="email"/>
+            <input type="email" class="form-control" name="email" id="email" value="{{email}}"/>
             <span class="help-block">Your email will only be used for account recovery</span>
           </div>
 
           <div class="form-group">
             <label class="control-label" for="externalWebId">External WebID:</label>
-            <input type="text" class="form-control" name="externalWebId" id="externalWebId"/>
+            <input type="text" class="form-control" name="externalWebId" id="externalWebId" value="{{externalWebId}}"/>
             <span class="help-block">
                 We will generate a Web ID when you register, but if you already have a Web ID hosted elsewhere that you'd prefer to use to log in, enter it here
             </span>
@@ -75,7 +75,7 @@
             {{#if tocUri}}
               <div class="checkbox">
                 <label>
-                  <input type="checkbox" name="acceptToc" value="true">
+                  <input type="checkbox" name="acceptToc" value="true" {{acceptToc ? "checked" : ""}}>
                   I agree to the <a href="{{tocUri}}" target="_blank">Terms &amp; Conditions</a> of this service
                 </label>
               </div>

--- a/lib/models/user-account.js
+++ b/lib/models/user-account.js
@@ -77,6 +77,17 @@ class UserAccount {
   }
 
   /**
+   * Returns the Uri to the account's Pod
+   *
+   * @return {string}
+   */
+  get podUri () {
+    const webIdUrl = url.parse(this.webId)
+    const podUrl = `${webIdUrl.protocol}//${webIdUrl.host}`
+    return url.format(podUrl)
+  }
+
+  /**
    * Returns the URI of the WebID Profile for this account.
    * Usage:
    *

--- a/lib/requests/auth-request.js
+++ b/lib/requests/auth-request.js
@@ -150,10 +150,10 @@ class AuthRequest {
    *
    * @param error {Error}
    */
-  error (error) {
+  error (error, body) {
     error.statusCode = error.statusCode || 400
 
-    this.renderForm(error)
+    this.renderForm(error, body)
   }
 
   /**

--- a/lib/requests/create-account-request.js
+++ b/lib/requests/create-account-request.js
@@ -91,7 +91,7 @@ class CreateAccountRequest extends AuthRequest {
       request.validate()
       await request.createAccount()
     } catch (error) {
-      request.error(error)
+      request.error(error, req.body)
     }
   }
 
@@ -106,7 +106,7 @@ class CreateAccountRequest extends AuthRequest {
   /**
    * Renders the Register form
    */
-  renderForm (error) {
+  renderForm (error, data = {}) {
     let authMethod = this.accountManager.authMethod
 
     let params = Object.assign({}, this.authQueryParams, {
@@ -116,7 +116,12 @@ class CreateAccountRequest extends AuthRequest {
       registerDisabled: authMethod === 'tls',
       returnToUrl: this.returnToUrl,
       tocUri: this.tocUri,
-      disablePasswordChecks: this.disablePasswordChecks
+      disablePasswordChecks: this.disablePasswordChecks,
+      username: data.username,
+      name: data.name,
+      email: data.email,
+      externalWebId: data.externalWebId,
+      acceptToc: data.acceptToc
     })
 
     if (error) {

--- a/lib/requests/create-account-request.js
+++ b/lib/requests/create-account-request.js
@@ -121,7 +121,8 @@ class CreateAccountRequest extends AuthRequest {
       name: data.name,
       email: data.email,
       externalWebId: data.externalWebId,
-      acceptToc: data.acceptToc
+      acceptToc: data.acceptToc,
+      connectExternalWebId: data.connectExternalWebId
     })
 
     if (error) {

--- a/lib/requests/create-account-request.js
+++ b/lib/requests/create-account-request.js
@@ -314,8 +314,15 @@ class CreateOidcAccountRequest extends CreateAccountRequest {
       })
   }
 
+  /**
+   * Generate the response for the account creation
+   *
+   * @param userAccount {UserAccount}
+   *
+   * @return {UserAccount}
+   */
   sendResponse (userAccount) {
-    let redirectUrl = this.returnToUrl || this.loginUrl()
+    let redirectUrl = this.returnToUrl || userAccount.podUri
     this.response.redirect(redirectUrl)
 
     return userAccount


### PR DESCRIPTION
This gives an alternative fix to https://github.com/solid/node-solid-server/pull/1270 by keeping externalWebID in form, but presenting it as an opt-in part of the form that must be "opened" by checking a checkbox.

I've also labelled the checkbox with *Advanced feature*, which would probably deter most users who don't know what the feature involves. But I've also changed the description a bit, so that those who do want to understand the externalWebID field better might do so.