### PR TITLE
This helps the data browser know whether or not a ACL can be deleted

### DIFF
--- a/default-templates/new-account/.acl
+++ b/default-templates/new-account/.acl
@@ -2,6 +2,9 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
+# Indicates that root is the root of the Pod
+</> a sp:Storage.
+
 # The homepage is readable by the public
 <#public>
     a acl:Authorization;


### PR DESCRIPTION
Root ACLs should never be deleted. (https://github.com/solid/node-solid-server/issues/1289)

This hack is working with solid-ui to indicate whether a ACL resource is working toward the root container of a Pod. (https://github.com/solid/solid-ui/pull/96)