### PR TITLE
PR # 1282 with minimized rewrite on ressource-mapper.js

### DIFF
--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -45,7 +45,7 @@ async function handler (req, res, next) {
 
   let ret
   try {
-    ret = await ldp.get(options)
+    ret = await ldp.get(options, req.accepts('html'))
   } catch (err) {
     // use globHandler if magic is detected
     if (err.status === 404 && glob.hasMagic(path)) {

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -437,7 +437,7 @@ class LDP {
     requestUrl = requestUrl.replace(/\/*$/, '/')
 
     const { path: containerFilePath } = await this.resourceMapper.mapUrlToFile({ url: requestUrl })
-    let fileName = slug + extension
+    let fileName = slug.endsWith(extension) || slug.endsWith(this.suffixAcl) || slug.endsWith(this.suffixMeta) ? slug : slug + extension
     if (await promisify(fs.exists)(utilPath.join(containerFilePath, fileName))) {
       fileName = `${uuid.v1()}-${fileName}`
     }

--- a/lib/resource-mapper.js
+++ b/lib/resource-mapper.js
@@ -7,7 +7,7 @@ const HTTPError = require('./http-error')
 
 /*
  * A ResourceMapper maintains the mapping between HTTP URLs and server filenames,
- * following the principles of the “sweet spot” discussed in
+ * following the principles of the "sweet spot" discussed in
  * https://www.w3.org/DesignIssues/HTTPFilenameMapping.html
  *
  * This class implements this mapping in a single place
@@ -91,9 +91,10 @@ class ResourceMapper {
     if (filePath.indexOf('/..') >= 0) {
       throw new Error('Disallowed /.. segment in URL')
     }
+    let isFolder = filePath.endsWith('/')
     let isIndex = searchIndex && filePath.endsWith('/')
 
-    // Create the path for a new file
+    // Create the path for a new ressource
     let path
     if (createIfNotExists) {
       path = filePath
@@ -105,7 +106,7 @@ class ResourceMapper {
         path += this._indexFilename
       }
       // If the extension is not correct for the content type, append the correct extension
-      if (searchIndex && this._getContentTypeByExtension(path) !== contentType) {
+      if (!isFolder && this._getContentTypeByExtension(path) !== contentType) {
         path += `$${contentType in extensions ? `.${extensions[contentType][0]}` : '.unknown'}`
       }
     // Determine the path of an existing file
@@ -116,13 +117,13 @@ class ResourceMapper {
 
       // Find a file with the same name (minus the dollar extension)
       let match = ''
-      if (searchIndex) {
+      if (match === '') {  // always true to keep indentation
         const files = await this._readdir(folder)
         // Search for files with the same name (disregarding a dollar extension)
-        if (!isIndex) {
+        if (!isFolder) {
           match = files.find(f => this._removeDollarExtension(f) === filename)
         // Check if the index file exists
-        } else if (files.includes(this._indexFilename)) {
+        } else if (searchIndex && files.includes(this._indexFilename)) {
           match = this._indexFilename
         }
       }
@@ -137,7 +138,6 @@ class ResourceMapper {
       path = `${folder}${match}`
       contentType = this._getContentTypeByExtension(match)
     }
-
     return { path, contentType: contentType || this._defaultContentType }
   }
 


### PR DESCRIPTION
@michielbdejong @jaxoncreed @RubenVerborgh 

This PR # 1282 has been rewritten to minimize any change other than strictly needed by the fact that `index.html` is created/checked only if explicitly asked on `get` accept header

- change made by @jaxoncreed on get.js in PR # 1260 + the consequence on resource-mapper.js

-- that introduce the fact that for resource-mapper.js called by get.js the searchIndex is usually false and  resource-mapper.js uses it only in conjonction with a container (no meaning for a file)

 -- the tests on searchIndex needed to be replaced by a check that we have a file (!isFolder) and if we have a folder the we check if we a looking for an index.html file (in the resource-mapper original code the test where made  falsely on searchIndex that was always true by default and not set in get.js)
there is a fake if just for diff indentation (to be deleted)

- resource-mapper.js introduced the obligation to have a contentType that implies that ldp.post added an extension to all slugs including .acl, .meta and were created by ldp.post as .acl.ttl and .meta.acl, and also that any slug containing an extension was creating a file with a double extension (foo.ttl slug gave foo.tll.tll resource). That is the change introduced to ldp.js

Sorry to insist but I hope that these explanations avoid any reasonable doubt to push this PR or the original PR # 1282 and to make a NSSv5.1.8 to dev.inrupt.net and then to solid.community
