### PR TITLE
Link to GitHub NSS instead of the Solid CG wiki

### DIFF
--- a/default-templates/server/index.html
+++ b/default-templates/server/index.html
@@ -45,7 +45,7 @@
       <dd>{{serverDescription}}</dd>
       {{/if}}
       <dt>Details</dt>
-      <dd>Running on <a href="https://www.w3.org/community/solid/wiki/">Solid {{serverVersion}}</a></dd>
+      <dd>Running on <a href="https://github.com/solid/node-solid-server/releases/tag/v{{serverVersion}}">Solid {{serverVersion}}</a></dd>
     </dl>
   </section>
 </div>


### PR DESCRIPTION
This is merely a suggestion, but I think this fits given the versioning of NSS in the link text.