### PR TITLE
Allow apps to access the MS-Author-Via header

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -31,7 +31,7 @@ const corsSettings = cors({
   methods: [
     'OPTIONS', 'HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'
   ],
-  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate',
+  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via',
   credentials: true,
   maxAge: 1728000,
   origin: true,

--- a/lib/handlers/cors-proxy.js
+++ b/lib/handlers/cors-proxy.js
@@ -11,7 +11,7 @@ const validUrl = require('valid-url')
 
 const CORS_SETTINGS = {
   methods: 'GET',
-  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, Content-Length, Content-Location',
+  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, Content-Length, Content-Location, MS-Author-Via',
   maxAge: 1728000,
   origin: true
 }

--- a/test/integration/header-test.js
+++ b/test/integration/header-test.js
@@ -20,6 +20,16 @@ describe('Header handler', () => {
     request = supertest(server)
   })
 
+  describe('MS-Author-Via', () => {
+    describeHeaderTest('read/append for the public', {
+      resource: '/public-ra',
+      headers: {
+        'MS-Author-Via': 'SPARQL',
+        'Access-Control-Expose-Headers': /(^|,\s*)MS-Author-Via(,|$)/
+      }
+    })
+  })
+
   describe('WAC-Allow', () => {
     describeHeaderTest('read/append for the public', {
       resource: '/public-ra',

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -106,7 +106,7 @@ describe('HTTP APIs', function () {
           .expect('Access-Control-Allow-Origin', 'http://example.com')
           .expect('Access-Control-Allow-Credentials', 'true')
           .expect('Access-Control-Allow-Methods', 'OPTIONS,HEAD,GET,PATCH,POST,PUT,DELETE')
-          .expect('Access-Control-Expose-Headers', 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate')
+          .expect('Access-Control-Expose-Headers', 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via')
           .expect(204, done)
       })
 


### PR DESCRIPTION
The `MS-Author-Via` header is used by rdflib to detect whether it can send PUT requests.
This used to not be a problem since rdflib would assume it would work, this assumption has now been removed (see https://github.com/linkeddata/rdflib.js/issues/359), so it will fail until it can read this header.

Fixes #1314.