### PR TITLE
PUT copy body for contentType application/json

### DIFF
--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -156,12 +156,6 @@ class LDP {
     }
     // const { url: putUrl } = await this.resourceMapper.mapFileToUrl({ path: resourceUrl, hostname })
 
-    // HACK: the middleware in webid-oidc.js uses body-parser, thus ending the stream of data
-    // for JSON bodies. So, the stream needs to be reset
-    if (contentType.includes('application/json')) {
-      stream = intoStream(JSON.stringify(stream.body))
-    }
-
     await ldp.put(resourceUrl, stream, contentType)
     return URL.parse(originalUrl).path
   }
@@ -240,6 +234,11 @@ class LDP {
 
     // Directory created, now write the file
     return withLock(path, { mustExist: false }, () => new Promise((resolve, reject) => {
+      // HACK: the middleware in webid-oidc.js uses body-parser, thus ending the stream of data
+      // for JSON bodies. So, the stream needs to be reset
+      if (contentType.includes('application/json')) {
+        stream = intoStream(JSON.stringify(stream.body))
+      }
       const file = stream.pipe(fs.createWriteStream(path))
       file.on('error', function () {
         reject(error(500, 'Error writing data'))


### PR DESCRIPTION
@jaxoncreed 
move the steam hack inside from before call to ldp.put, to inside ldp.put.
So it is used by POST and PUT.
Checked on a docker server
npm test passed before and after commit

should solve issue #1339 