### PR TITLE
Get valid mashlib html file location

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -67,7 +67,7 @@ function createApp (argv = {}) {
 
   // Serve the public 'common' directory (for shared CSS files, etc)
   app.use('/common', express.static(path.join(__dirname, '../common')))
-  app.use('/', express.static(path.join(__dirname, '../node_modules/mashlib/dist'), { index: false }))
+  app.use('/', express.static(path.dirname(require.resolve('mashlib/dist/index.html')), { index: false }))
   routeResolvedFile(app, '/common/js/', 'solid-auth-client/dist-lib/solid-auth-client.bundle.js')
   routeResolvedFile(app, '/common/js/', 'solid-auth-client/dist-lib/solid-auth-client.bundle.js.map')
   app.use('/.well-known', express.static(path.join(__dirname, '../common/well-known')))

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -89,7 +89,7 @@ async function handler (req, res, next) {
 
     if (useDataBrowser) {
       res.set('Content-Type', 'text/html')
-      const defaultDataBrowser = _path.join(__dirname, '../../node_modules/mashlib/dist/index.html')
+      const defaultDataBrowser = require.resolve('mashlib/dist/index.html')
       const dataBrowserPath = ldp.dataBrowserPath === 'default' ? defaultDataBrowser : ldp.dataBrowserPath
       debug('   sending data browser file: ' + dataBrowserPath)
       res.sendFile(dataBrowserPath)


### PR DESCRIPTION
In the latest npm, node_modules is flattened, so it shouldn't be located based on the location of solid-server.

This solves https://github.com/solid/node-solid-server/issues/1382 and https://github.com/solid/node-solid-server/issues/1383