### PR TITLE
reject .acl with bad contentType and related tests

### DIFF
--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -143,6 +143,12 @@ class LDP {
       if (slug.match(/\/|\||:/)) {
         throw error(400, 'The name of new file POSTed may not contain : | or /')
       }
+      // not to break pod ACL must have text/turtle contentType
+      if (slug.endsWith(this.suffixAcl) || extension === this.suffixAcl) {
+        if (contentType !== this.aclContentType) {
+          throw error(415, 'POST contentType for ACL must be text/turtle')
+        }
+      }
     }
     // Containers should not receive an extension
     if (container) {
@@ -212,6 +218,11 @@ class LDP {
     if (!contentType) {
       throw error(415,
         'PUT request require a valid content type via the Content-Type header')
+    }
+
+    // not to break pod : url ACL must have text/turtle contentType
+    if ((url.url || url).endsWith(this.suffixAcl) && contentType !== this.aclContentType) {
+      throw error(415, 'PUT contentType for ACL must be text-turtle')
     }
 
     // First check if we are above quota

--- a/lib/ldp.js
+++ b/lib/ldp.js
@@ -38,6 +38,11 @@ class LDP {
   constructor (argv = {}) {
     extend(this, argv)
 
+    // Acl contentType
+    if (!this.aclContentType) {
+      this.aclContentType = 'text/turtle'
+    }
+
     // Suffixes
     if (!this.suffixAcl) {
       this.suffixAcl = '.acl'

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -481,6 +481,12 @@ describe('HTTP APIs', function () {
         .set('content-type', 'text/turtle')
         .expect(201, done)
     })
+    it('should reject create .acl resource, if contentType not text/turtle', function (done) {
+      server.put('/put-resource-1.acl')
+        .send(putRequestBody)
+        .set('content-type', 'text/plain')
+        .expect(415, done)
+    })
     it('should create directories if they do not exist', function (done) {
       server.put('/foo/bar/baz.ttl')
         .send(putRequestBody)
@@ -590,6 +596,13 @@ describe('HTTP APIs', function () {
     it('should error with 415 if the body is provided but there is no content-type header', function (done) {
       server.post('/post-tests/')
         .set('slug', 'post-resource-rdf-no-content-type')
+        .send(postRequest1Body)
+        .set('content-type', '')
+        .expect(415, done)
+    })
+    it('should error with 415 if file.acl and contentType not text/turtle', function (done) {
+      server.post('/post-tests/')
+        .set('slug', 'post-acl-no-content-type.acl')
         .send(postRequest1Body)
         .set('content-type', '')
         .expect(415, done)

--- a/test/integration/ldp-test.js
+++ b/test/integration/ldp-test.js
@@ -163,6 +163,13 @@ describe('LDP', function () {
         assert.equal(err.status, 415)
       })
     })
+
+    it('should fail if file.acl and content type not text/turtle', () => {
+      var stream = stringToStream('hello world')
+      return ldp.put('/resources/testPut.txt.acl', stream, 'text/plain').catch(err => {
+        assert.equal(err.status, 415)
+      })
+    })
   })
 
   describe('delete', function () {


### PR DESCRIPTION
issue #1400 relating to avoid being locked out by ACL with bad contentType
This pull rejects .acl files created with POST or PUT when contentType is not `text/turtle`