### PR TITLE
update Dockerfile to node:lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM node:8.11.2-onbuild
+FROM node:lts
+
+# build
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+
+# start
 EXPOSE 8443
 COPY config.json-default config.json
 RUN openssl req \


### PR DESCRIPTION
As NSS did increases is node.js version requirement, there is a need to update the Dockerfile.
Node onbuild version is not available after V8. 
The same implementation in /usr/src/app/ has been kept.
So there is no change for users.