### PR TITLE
Support for new token (NSS)

### DIFF
--- a/bin/lib/start.js
+++ b/bin/lib/start.js
@@ -58,6 +58,10 @@ function bin (argv, server) {
     delete argv['emailAuthPass']
   }
 
+  if (!argv.tokenTypesSupported) {
+    argv.tokenTypesSupported = ['legacyPop', 'dpop']
+  }
+
   // Set up --no-*
   argv.live = !argv.noLive
 

--- a/lib/api/authn/webid-oidc.js
+++ b/lib/api/authn/webid-oidc.js
@@ -33,7 +33,7 @@ function initialize (app, argv) {
 
   // Perform the actual authentication
   app.use('/', async (req, res, next) => {
-    oidc.rs.authenticate()(req, res, (err) => {
+    oidc.rs.authenticate({ tokenTypesSupported: argv.tokenTypesSupported })(req, res, (err) => {
       // Error handling should be deferred to the ldp in case a user with a bad token is trying
       // to access a public resource
       if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-server",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The support for new token effort contains the following PRs
 -  NSS (https://github.com/solid/node-solid-server/pull/1427)
 - oidc-auth-manager (https://github.com/solid/oidc-auth-manager/pull/48)
 - oidc-op (https://github.com/solid/oidc-op/pull/22)
 - oidc-rs (https://github.com/solid/oidc-rs/pull/5)