### PR TITLE
Fix patch mkdir -p

### DIFF
--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -60,7 +60,16 @@ async function patchHandler (req, res, next) {
     const pathSplit = path.split('/')
     const directory = pathSplit.slice(0, pathSplit.length - 1).join('/')
     if (!fs.existsSync(directory)) {
-      fx.mkdirSync(directory, { recursive: true })
+      debug('PATCH -- mkdirp <%s>', directory)
+      await new Promise((resolve, reject) => {
+        fx.mkdir(directory, { recursive: true }, (err) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
+      })
     }
 
     // Patch the graph and write it back to the file
@@ -96,6 +105,7 @@ function readGraph (resource) {
         if (err.code === 'ENOENT') {
           fileContents = ''
           // Fail on all other errors
+          debug('PATCH to create')
         } else {
           return reject(error(500, `Original file read error: ${err}`))
         }

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -61,15 +61,7 @@ async function patchHandler (req, res, next) {
     const directory = pathSplit.slice(0, pathSplit.length - 1).join('/')
     if (!fs.existsSync(directory)) {
       debug('PATCH -- mkdirp <%s>', directory)
-      await new Promise((resolve, reject) => {
-        fx.mkdir(directory, { recursive: true }, (err) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve()
-          }
-        })
-      })
+      fx.mkdirSync(directory)
     }
 
     // Patch the graph and write it back to the file


### PR DESCRIPTION
I can't reproduce it in isolation, but apparently there is a glitch that makes `fx.mkdirSync` fail. Using `fx.mkdir` instead fixes #1493.