### PR TITLE
Remove the MS-Author-Via header

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -32,7 +32,7 @@ const corsSettings = cors({
   methods: [
     'OPTIONS', 'HEAD', 'GET', 'PATCH', 'POST', 'PUT', 'DELETE'
   ],
-  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via, X-Powered-By',
+  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, X-Powered-By',
   credentials: true,
   maxAge: 1728000,
   origin: true,

--- a/lib/handlers/cors-proxy.js
+++ b/lib/handlers/cors-proxy.js
@@ -13,7 +13,7 @@ const validUrl = require('valid-url')
 
 const CORS_SETTINGS = {
   methods: 'GET',
-  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, Content-Length, Content-Location, MS-Author-Via, X-Powered-By',
+  exposedHeaders: 'Authorization, User, Location, Link, Vary, Last-Modified, Content-Length, Content-Location, X-Powered-By',
   maxAge: 1728000,
   origin: true
 }

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -27,8 +27,6 @@ async function handler (req, res, next) {
   const requestedType = negotiator.mediaType()
   const possibleRDFType = negotiator.mediaType(RDFs)
 
-  res.header('MS-Author-Via', 'SPARQL')
-
   // Set live updates
   if (ldp.live) {
     res.header('Updates-Via', ldp.resourceMapper.resolveUrl(req.hostname).replace(/^http/, 'ws'))

--- a/lib/handlers/patch.js
+++ b/lib/handlers/patch.js
@@ -23,7 +23,6 @@ const DEFAULT_FOR_NEW_CONTENT_TYPE = 'text/turtle'
 // Handles a PATCH request
 async function patchHandler (req, res, next) {
   debug(`PATCH -- ${req.originalUrl}`)
-  res.header('MS-Author-Via', 'SPARQL')
   try {
     // Obtain details of the target resource
     const ldp = req.app.locals.ldp

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -8,7 +8,6 @@ const { stringToStream } = require('../utils')
 
 async function handler (req, res, next) {
   debug(req.originalUrl)
-  res.header('MS-Author-Via', 'SPARQL')
 
   const contentType = req.get('content-type')
   if (isAuxiliary(req)) {

--- a/test/integration/header-test.js
+++ b/test/integration/header-test.js
@@ -20,16 +20,6 @@ describe('Header handler', () => {
     request = supertest(server)
   })
 
-  describe('MS-Author-Via', () => {
-    describeHeaderTest('read/append for the public', {
-      resource: '/public-ra',
-      headers: {
-        'MS-Author-Via': 'SPARQL',
-        'Access-Control-Expose-Headers': /(^|,\s*)MS-Author-Via(,|$)/
-      }
-    })
-  })
-
   describe('WAC-Allow', () => {
     describeHeaderTest('read/append for the public', {
       resource: '/public-ra',

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -86,7 +86,7 @@ describe('HTTP APIs', function () {
           .expect('Access-Control-Allow-Origin', 'http://example.com')
           .expect('Access-Control-Allow-Credentials', 'true')
           .expect('Access-Control-Allow-Methods', 'OPTIONS,HEAD,GET,PATCH,POST,PUT,DELETE')
-          .expect('Access-Control-Expose-Headers', 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, MS-Author-Via, X-Powered-By')
+          .expect('Access-Control-Expose-Headers', 'Authorization, User, Location, Link, Vary, Last-Modified, ETag, Accept-Patch, Accept-Post, Updates-Via, Allow, WAC-Allow, Content-Length, WWW-Authenticate, X-Powered-By')
           .expect(204, done)
       })
 


### PR DESCRIPTION
In https://github.com/solid/specification/issues/124 it has been resolved to not bring the `MS-Author-Via` header into the spec, as it has been obsoleted by `Accept-Patch`, as it seems that NSS has implemented.

This PR removes it from the places that I could find it.