### PR TITLE
update n3-patch to solid/protocol v0.9.0

### DIFF
--- a/lib/handlers/patch/n3-patch-parser.js
+++ b/lib/handlers/patch/n3-patch-parser.js
@@ -20,16 +20,26 @@ async function parsePatchDocument (targetURI, patchURI, patchText) {
 
   // Query the N3 document for insertions and deletions
   let firstResult
-  try {
+  try { // solid/protocol v0.9.0
     firstResult = await queryForFirstResult(patchGraph, `${PREFIXES}
     SELECT ?insert ?delete ?where WHERE {
-      ?patch solid:patches <${targetURI}>.
+      ?patch a solid:InsertDeletePatch.
       OPTIONAL { ?patch solid:inserts ?insert. }
       OPTIONAL { ?patch solid:deletes ?delete. }
       OPTIONAL { ?patch solid:where   ?where.  }
     }`)
   } catch (err) {
-    throw error(400, `No patch for ${targetURI} found.`, err)
+    try { // deprecated, kept for compatibility
+      firstResult = await queryForFirstResult(patchGraph, `${PREFIXES}
+      SELECT ?insert ?delete ?where WHERE {
+        ?patch solid:patches <${targetURI}>.
+        OPTIONAL { ?patch solid:inserts ?insert. }
+        OPTIONAL { ?patch solid:deletes ?delete. }
+        OPTIONAL { ?patch solid:where   ?where.  }
+      }`)
+    } catch (err) {
+      throw error(400, 'No n3-patch found.', err)
+    }
   }
 
   // Return the insertions and deletions as an rdflib patch document

--- a/lib/header.js
+++ b/lib/header.js
@@ -67,7 +67,9 @@ async function linksHandler (req, res, next) {
   }
   const fileMetadata = new metadata.Metadata()
   if (filename.endsWith('/')) {
-    if (req.path === '/') fileMetadata.isStorage = true
+    // do not add storage header in serverUri
+    // debug.metadata(req.hostname +'\n' + req.app.locals.host.serverUri)
+    if (req.path === '/' && req.app.locals.host.serverUri.contains(req.hostname)) fileMetadata.isStorage = true
     fileMetadata.isContainer = true
     fileMetadata.isBasicContainer = true
   } else {

--- a/lib/header.js
+++ b/lib/header.js
@@ -67,6 +67,7 @@ async function linksHandler (req, res, next) {
   }
   const fileMetadata = new metadata.Metadata()
   if (req.path.endsWith('/')) {
+    // do not add storage header in serverUri
     if (req.path === '/') fileMetadata.isStorage = true
     fileMetadata.isContainer = true
     fileMetadata.isBasicContainer = true

--- a/lib/header.js
+++ b/lib/header.js
@@ -66,10 +66,8 @@ async function linksHandler (req, res, next) {
     return next(error(404, 'Trying to access metadata file as regular file'))
   }
   const fileMetadata = new metadata.Metadata()
-  if (filename.endsWith('/')) {
-    // do not add storage header in serverUri
-    // debug.metadata(req.hostname +'\n' + req.app.locals.host.serverUri)
-    if (req.path === '/' && req.app.locals.host.serverUri.contains(req.hostname)) fileMetadata.isStorage = true
+  if (req.path.endsWith('/')) {
+    if (req.path === '/') fileMetadata.isStorage = true
     fileMetadata.isContainer = true
     fileMetadata.isBasicContainer = true
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2545,9 +2545,9 @@
       "integrity": "sha512-J2WtYj2Pl6LBEG214XmbGw1gzZEsYuinQFPqYtpZDB3/vm49qNlrcbJrTMkHKmdRDdmXYwkG0tgOBJsuI+J12Q=="
     },
     "canonicalize": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
-      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -6185,6 +6185,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/n3/-/n3-1.11.1.tgz",
       "integrity": "sha512-yeTeYoatabMs6IMv71dYSIfgf+s+4DpLrnvRv8CKGRLnAt1lfWcnb+mwP67PZKq7Wvh7MCIGXaflayPkn0WzHw==",
+      "dev": true,
       "requires": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"
@@ -7404,17 +7405,28 @@
       }
     },
     "rdflib": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.2.10.tgz",
-      "integrity": "sha512-qP87jqNdI4FeV9gG14ASpqiivlYJaxqOqD3wpS5d0BIOJoEVmad3erLl+3qWcGkLbhcgG5DMl4ynMzqLJDXzWg==",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.2.14.tgz",
+      "integrity": "sha512-j4lmXORni5RGcdzVBJBpCuh15qSyvXO14A5asaPBYJu/QIb8NWx/5tK0GQ7HXKbJF8tupVxdHUq04EHzzGCJdw==",
       "requires": {
         "@babel/runtime": "^7.16.0",
         "async": "^3.2.2",
         "cross-fetch": "^3.1.4",
         "jsonld": "^5.2.0",
-        "n3": "^1.11.1",
-        "solid-namespace": "^0.5.1",
+        "n3": "^1.12.2",
+        "solid-namespace": "^0.5.2",
         "xmldom": "^0.6.0"
+      },
+      "dependencies": {
+        "n3": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/n3/-/n3-1.12.2.tgz",
+          "integrity": "sha512-vY1HBEraMPWQFLEK6sn67DeGMqTuwXnlEYpZ8gTVukKQSz2f44d+t+ZcmwEt8c99FlVAbpmMb/435Q8t0OC+7w==",
+          "requires": {
+            "queue-microtask": "^1.1.2",
+            "readable-stream": "^3.6.0"
+          }
+        }
       }
     },
     "react": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "nodemailer": "^6.7.0",
     "oidc-op-express": "^0.0.3",
     "owasp-password-strength-test": "^1.3.0",
-    "rdflib": "^2.2.10",
+    "rdflib": "^2.2.14",
     "recursive-readdir": "^2.2.2",
     "request": "^2.88.2",
     "rimraf": "^3.0.2",

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -167,8 +167,7 @@ describe('HTTP APIs', function () {
         .end(done)
     })
 
-    // This test is probably wrong: it is not a container if there is an index page
-    it.skip('should have set Link as resource on a implicit index page', function (done) {
+    it('should have set Link as Container/BasicContainer on a implicit index page', function (done) {
       server.options('/sampleContainer/')
         .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#BasicContainer>; rel="type"/)
         .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#Container>; rel="type"/)

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -167,7 +167,7 @@ describe('HTTP APIs', function () {
         .end(done)
     })
 
-    it('should have set Link as Container/BasicContainer on a implicit index page', function (done) {
+    it('should have set Link as Container/BasicContainer on an implicit index page', function (done) {
       server.options('/sampleContainer/')
         .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#BasicContainer>; rel="type"/)
         .expect('Link', /<http:\/\/www.w3.org\/ns\/ldp#Container>; rel="type"/)

--- a/test/integration/patch-test.js
+++ b/test/integration/patch-test.js
@@ -60,12 +60,12 @@ describe('PATCH', () => {
       patch: '<> a solid:Patch.'
     }, { // expected:
       status: 400,
-      text: 'No patch for https://tim.localhost:7777/read-write.ttl found'
+      text: 'No n3-patch found' // patch for https://tim.localhost:7777/read-write.ttl found'
     }))
 
     describe('with neither insert nor delete', describePatch({
       path: '/read-write.ttl',
-      patch: '<> solid:patches <https://tim.localhost:7777/read-write.ttl>.'
+      patch: '<> a solid:InsertDeletePatch.'
     }, { // expected:
       status: 400,
       text: 'Patch should at least contain inserts or deletes'
@@ -76,7 +76,7 @@ describe('PATCH', () => {
     describe('on a non-existing file', describePatch({
       path: '/new.ttl',
       exists: false,
-      patch: `<> solid:patches <https://tim.localhost:7777/new.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
       status: 200,
@@ -86,7 +86,7 @@ describe('PATCH', () => {
 
     describe('on a resource with read-only access', describePatch({
       path: '/read-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/read-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
       status: 403,
@@ -95,7 +95,7 @@ describe('PATCH', () => {
 
     describe('on a resource with append-only access', describePatch({
       path: '/append-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/append-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
       status: 200,
@@ -105,7 +105,7 @@ describe('PATCH', () => {
 
     describe('on a resource with write-only access', describePatch({
       path: '/write-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/write-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. }.`
     }, { // expected:
       status: 200,
@@ -116,7 +116,7 @@ describe('PATCH', () => {
     describe('on a resource with parent folders that do not exist', describePatch({
       path: '/folder/cool.ttl',
       exists: false,
-      patch: `<> solid:patches <https://tim.localhost:7777/folder/cool.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
         solid:inserts { <x> <y> <z>. }.`
     }, {
       status: 200,
@@ -129,7 +129,7 @@ describe('PATCH', () => {
     describe('on a non-existing file', describePatch({
       path: '/new.ttl',
       exists: false,
-      patch: `<> solid:patches <https://tim.localhost:7777/new.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { ?a <y> <z>. };
                  solid:where   { ?a <b> <c>. }.`
     }, { // expected:
@@ -139,7 +139,7 @@ describe('PATCH', () => {
 
     describe('on a resource with read-only access', describePatch({
       path: '/read-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/read-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { ?a <y> <z>. };
                  solid:where   { ?a <b> <c>. }.`
     }, { // expected:
@@ -149,7 +149,7 @@ describe('PATCH', () => {
 
     describe('on a resource with append-only access', describePatch({
       path: '/append-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/append-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { ?a <y> <z>. };
                  solid:where   { ?a <b> <c>. }.`
     }, { // expected:
@@ -159,7 +159,7 @@ describe('PATCH', () => {
 
     describe('on a resource with write-only access', describePatch({
       path: '/write-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/write-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { ?a <y> <z>. };
                  solid:where   { ?a <b> <c>. }.`
     }, { // expected:
@@ -173,7 +173,7 @@ describe('PATCH', () => {
     describe('on a resource with read-append access', () => {
       describe('with a matching WHERE clause', describePatch({
         path: '/read-append.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-append.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:inserts { ?a <y> <z>. };
                    solid:where   { ?a <b> <c>. }.`
       }, { // expected:
@@ -184,7 +184,7 @@ describe('PATCH', () => {
 
       describe('with a non-matching WHERE clause', describePatch({
         path: '/read-append.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-append.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:where   { ?a <y> <z>. };
                    solid:inserts { ?a <s> <t>. }.`
       }, { // expected:
@@ -196,7 +196,7 @@ describe('PATCH', () => {
     describe('on a resource with read-write access', () => {
       describe('with a matching WHERE clause', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:inserts { ?a <y> <z>. };
                    solid:where   { ?a <b> <c>. }.`
       }, { // expected:
@@ -207,7 +207,7 @@ describe('PATCH', () => {
 
       describe('with a non-matching WHERE clause', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:where   { ?a <y> <z>. };
                    solid:inserts { ?a <s> <t>. }.`
       }, { // expected:
@@ -221,7 +221,7 @@ describe('PATCH', () => {
     describe('on a non-existing file', describePatch({
       path: '/new.ttl',
       exists: false,
-      patch: `<> solid:patches <https://tim.localhost:7777/new.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
       status: 409,
@@ -230,7 +230,7 @@ describe('PATCH', () => {
 
     describe('on a resource with read-only access', describePatch({
       path: '/read-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/read-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
       status: 403,
@@ -239,7 +239,7 @@ describe('PATCH', () => {
 
     describe('on a resource with append-only access', describePatch({
       path: '/append-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/append-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
       status: 403,
@@ -248,7 +248,7 @@ describe('PATCH', () => {
 
     describe('on a resource with write-only access', describePatch({
       path: '/write-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/write-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
       // Allowing the delete would either return 200 or 409,
@@ -260,7 +260,7 @@ describe('PATCH', () => {
 
     describe('on a resource with read-append access', describePatch({
       path: '/read-append.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/read-append.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
       status: 403,
@@ -270,7 +270,7 @@ describe('PATCH', () => {
     describe('on a resource with read-write access', () => {
       describe('with a patch for existing data', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:deletes { <a> <b> <c>. }.`
       }, { // expected:
         status: 200,
@@ -280,7 +280,7 @@ describe('PATCH', () => {
 
       describe('with a patch for non-existing data', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:deletes { <x> <y> <z>. }.`
       }, { // expected:
         status: 409,
@@ -289,7 +289,7 @@ describe('PATCH', () => {
 
       describe('with a matching WHERE clause', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:where   { ?a <b> <c>. };
                    solid:deletes { ?a <b> <c>. }.`
       }, { // expected:
@@ -300,7 +300,7 @@ describe('PATCH', () => {
 
       describe('with a non-matching WHERE clause', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:where   { ?a <y> <z>. };
                    solid:deletes { ?a <b> <c>. }.`
       }, { // expected:
@@ -314,7 +314,7 @@ describe('PATCH', () => {
     describe('on a non-existing file', describePatch({
       path: '/new.ttl',
       exists: false,
-      patch: `<> solid:patches <https://tim.localhost:7777/new.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. };
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
@@ -324,7 +324,7 @@ describe('PATCH', () => {
 
     describe('on a resource with read-only access', describePatch({
       path: '/read-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/read-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. };
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
@@ -334,7 +334,7 @@ describe('PATCH', () => {
 
     describe('on a resource with append-only access', describePatch({
       path: '/append-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/append-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. };
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
@@ -344,7 +344,7 @@ describe('PATCH', () => {
 
     describe('on a resource with write-only access', describePatch({
       path: '/write-only.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/write-only.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. };
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
@@ -357,7 +357,7 @@ describe('PATCH', () => {
 
     describe('on a resource with read-append access', describePatch({
       path: '/read-append.ttl',
-      patch: `<> solid:patches <https://tim.localhost:7777/read-append.ttl>;
+      patch: `<> a solid:InsertDeletePatch;
                  solid:inserts { <x> <y> <z>. };
                  solid:deletes { <a> <b> <c>. }.`
     }, { // expected:
@@ -368,7 +368,7 @@ describe('PATCH', () => {
     describe('on a resource with read-write access', () => {
       describe('executes deletes before inserts', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:inserts { <x> <y> <z>. };
                    solid:deletes { <x> <y> <z>. }.`
       }, { // expected:
@@ -378,7 +378,7 @@ describe('PATCH', () => {
 
       describe('with a patch for existing data', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:inserts { <x> <y> <z>. };
                    solid:deletes { <a> <b> <c>. }.`
       }, { // expected:
@@ -389,7 +389,7 @@ describe('PATCH', () => {
 
       describe('with a patch for non-existing data', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:inserts { <x> <y> <z>. };
                    solid:deletes { <q> <s> <s>. }.`
       }, { // expected:
@@ -399,7 +399,7 @@ describe('PATCH', () => {
 
       describe('with a matching WHERE clause', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:where   { ?a <b> <c>. };
                    solid:inserts { ?a <y> <z>. };
                    solid:deletes { ?a <b> <c>. }.`
@@ -411,7 +411,7 @@ describe('PATCH', () => {
 
       describe('with a non-matching WHERE clause', describePatch({
         path: '/read-write.ttl',
-        patch: `<> solid:patches <https://tim.localhost:7777/read-write.ttl>;
+        patch: `<> a solid:InsertDeletePatch;
                    solid:where   { ?a <y> <z>. };
                    solid:inserts { ?a <y> <z>. };
                    solid:deletes { ?a <b> <c>. }.`


### PR DESCRIPTION
- update n3-patch to solid/protocol v0.9.0 `solid:InsetDeletePatch` and move all tests
- keep deprecated `solid:patches` for compatibility issue with no tests