### PR TITLE
Docker image tests: add .pyc files to .gitignore

### DIFF
--- a/docker-image/.gitignore
+++ b/docker-image/.gitignore
@@ -1,3 +1,4 @@
 .pytest_cache/
 __pycache__
+*.pyc
 data/


### PR DESCRIPTION
The Docker image tests currently rely on Python 2 (from the image [aveltens/docker-testinfra](https://hub.docker.com/r/aveltens/docker-testinfra)), which creates `.pyc` cache files in the same directories the corresponding `.py` files are located in.