### PR TITLE
Docker image: update Node.js from v10 to v16 (current LTS version)

### DIFF
--- a/docker-image/src/Dockerfile
+++ b/docker-image/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:16-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache openssl

--- a/docker-image/test/test_image_foundations.py
+++ b/docker-image/test/test_image_foundations.py
@@ -29,8 +29,8 @@ def test_solid_home_dir_exists_and_owned_by_node(host):
 def test_node_command_is_available(host):
     assert host.exists("node")
 
-def test_node_version_is_10(host):
-    assert host.check_output("node --version").startswith('v10')
+def test_node_version_is_16(host):
+    assert host.check_output("node --version").startswith('v16')
 
 def test_openssl_command_is_available(host):
     assert host.exists("openssl")


### PR DESCRIPTION
As the official Docker image currently uses Node.js v10 (which has already reached its EOL), I would suggest updating to the current LTS version v16, which should also provide some performance benefits.